### PR TITLE
feat: message sent ui

### DIFF
--- a/src/pages/to/[username].tsx
+++ b/src/pages/to/[username].tsx
@@ -7,6 +7,7 @@ import { getUser, queryClient, sendMessage } from '@/api';
 
 const SendTo = ({ username }: { username: string }) => {
   const [message, setMessage] = useState('');
+  const [msgSent, setMsgSent] = useState<boolean>(false);
 
   const { data: user } = useQuery(
     ['user', { username }],
@@ -26,6 +27,7 @@ const SendTo = ({ username }: { username: string }) => {
         },
       }
     );
+    setMsgSent(true);
   };
 
   return (
@@ -51,7 +53,7 @@ const SendTo = ({ username }: { username: string }) => {
             </div>
 
             {/* Message */}
-            <div className='flex min-h-[160px] flex-col justify-between space-y-5 px-5 py-10 sm:space-y-0 sm:px-10 sm:py-7'>
+            <div className='flex min-h-[170px] flex-col justify-between space-y-5 px-5 py-10 sm:space-y-0 sm:px-10 sm:py-7'>
               <div className='chat-p receive inline-block self-start font-medium'>
                 Send me an anonymous message!
               </div>
@@ -65,28 +67,43 @@ const SendTo = ({ username }: { username: string }) => {
             {/* Send Message */}
             <form
               onSubmit={handleSend}
-              className='relative flex items-center justify-between bg-secondary-200 py-5 px-4 md:px-7'
+              className='relative flex h-[80px] items-center justify-between bg-secondary-200 py-5 px-4 md:h-[85px] md:px-7'
             >
-              <input
-                required
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                minLength={1}
-                maxLength={200}
-                type='text'
-                placeholder='Send an anonymous message..'
-                className='w-full rounded-full border-2 border-primary-100 bg-secondary-100 py-2 pl-5 pr-12 outline-none'
-              />
+              {!msgSent ? (
+                <>
+                  <input
+                    required
+                    value={message}
+                    onChange={(e) => setMessage(e.target.value)}
+                    minLength={1}
+                    maxLength={200}
+                    type='text'
+                    placeholder='Send an anonymous message..'
+                    className='w-full rounded-full border-2 border-primary-100 bg-secondary-100 py-2 pl-5 pr-12 outline-none transition-all'
+                  />
 
-              {isLoading ? (
-                <span className='loader absolute right-10' />
+                  {isLoading ? (
+                    <span className='loader absolute right-10' />
+                  ) : (
+                    <button
+                      type='submit'
+                      className='absolute right-10 cursor-pointer text-xl text-primary-100 transition-all md:right-12'
+                    >
+                      <RiSendPlaneFill />
+                    </button>
+                  )}
+                </>
               ) : (
-                <button
-                  type='submit'
-                  className='absolute right-10 cursor-pointer text-xl text-primary-100 md:right-12'
-                >
-                  <RiSendPlaneFill />
-                </button>
+                <div className='w-full'>
+                  <p className='text-center font-medium text-[#DAB5D3]'>
+                    Anonymous message sent!
+                  </p>
+                  <ul className='flex justify-center space-x-2 font-normal text-primary-100 [&>:nth-child(odd)]:cursor-pointer'>
+                    <li>Send Again</li>
+                    <li className='text-[#DAB5D3]'>|</li>
+                    <li>Create your own link</li>
+                  </ul>
+                </div>
               )}
             </form>
           </div>

--- a/src/pages/to/[username].tsx
+++ b/src/pages/to/[username].tsx
@@ -103,14 +103,14 @@ const SendTo = ({ username }: { username: string }) => {
                   </p>
                   <div className='flex justify-center space-x-2 font-normal text-primary-100 [&>:nth-child(odd)]:cursor-pointer [&>:nth-child(odd)]:transition-all [&>:nth-child(odd):hover]:text-[#ED6FD5]'>
                     <button type='button' onClick={() => setMsgSent(false)}>
-                      Send Again
+                      Send again
                     </button>
-                    <span className='text-[#DAB5D3]'>|</span>
+                    <span className='text-[#DAB5D3]'>•</span>
                     <button
                       type='button'
                       onClick={() => router.push('/create')}
                     >
-                      Create your own link
+                      Create your link
                     </button>
                   </div>
                 </div>

--- a/src/pages/to/[username].tsx
+++ b/src/pages/to/[username].tsx
@@ -3,11 +3,14 @@ import { dehydrate, useMutation, useQuery } from 'react-query';
 import { RiSendPlaneFill } from 'react-icons/ri';
 import Image from 'next/image';
 
+import { useRouter } from 'next/router';
 import { getUser, queryClient, sendMessage } from '@/api';
 
 const SendTo = ({ username }: { username: string }) => {
   const [message, setMessage] = useState('');
   const [msgSent, setMsgSent] = useState<boolean>(false);
+
+  const router = useRouter();
 
   const { data: user } = useQuery(
     ['user', { username }],
@@ -24,10 +27,10 @@ const SendTo = ({ username }: { username: string }) => {
       {
         onSuccess: () => {
           setMessage('');
+          setMsgSent(true);
         },
       }
     );
-    setMsgSent(true);
   };
 
   return (
@@ -98,11 +101,18 @@ const SendTo = ({ username }: { username: string }) => {
                   <p className='text-center font-medium text-[#DAB5D3]'>
                     Anonymous message sent!
                   </p>
-                  <ul className='flex justify-center space-x-2 font-normal text-primary-100 [&>:nth-child(odd)]:cursor-pointer'>
-                    <li>Send Again</li>
-                    <li className='text-[#DAB5D3]'>|</li>
-                    <li>Create your own link</li>
-                  </ul>
+                  <div className='flex justify-center space-x-2 font-normal text-primary-100 [&>:nth-child(odd)]:cursor-pointer [&>:nth-child(odd)]:transition-all [&>:nth-child(odd):hover]:text-[#ED6FD5]'>
+                    <button type='button' onClick={() => setMsgSent(false)}>
+                      Send Again
+                    </button>
+                    <span className='text-[#DAB5D3]'>|</span>
+                    <button
+                      type='button'
+                      onClick={() => router.push('/create')}
+                    >
+                      Create your own link
+                    </button>
+                  </div>
                 </div>
               )}
             </form>

--- a/src/pages/to/[username].tsx
+++ b/src/pages/to/[username].tsx
@@ -39,7 +39,7 @@ const SendTo = ({ username }: { username: string }) => {
           {/* Top */}
           <div className='card w-full overflow-hidden bg-secondary-100 md:w-[720px]'>
             <div className='flex items-center justify-between border-b-2 border-primary-100 bg-secondary-200 px-7 py-2'>
-              <p className='font-medium text-white'>
+              <p className='font-medium capitalize text-white'>
                 <span className='font-light text-gray-400'>To&#58;</span>{' '}
                 {username}
               </p>
@@ -67,7 +67,7 @@ const SendTo = ({ username }: { username: string }) => {
             {/* Send Message */}
             <form
               onSubmit={handleSend}
-              className='relative flex h-[80px] items-center justify-between bg-secondary-200 py-5 px-4 md:h-[85px] md:px-7'
+              className='relative flex h-[100px] items-center justify-between bg-secondary-200 py-5 px-4 md:h-[85px] md:px-7'
             >
               {!msgSent ? (
                 <>
@@ -79,7 +79,7 @@ const SendTo = ({ username }: { username: string }) => {
                     maxLength={200}
                     type='text'
                     placeholder='Send an anonymous message..'
-                    className='w-full rounded-full border-2 border-primary-100 bg-secondary-100 py-2 pl-5 pr-12 outline-none transition-all'
+                    className='w-full rounded-full border-2 border-primary-100 bg-secondary-100 py-3 px-5 pr-12 outline-none transition-all md:py-2'
                   />
 
                   {isLoading ? (
@@ -87,7 +87,7 @@ const SendTo = ({ username }: { username: string }) => {
                   ) : (
                     <button
                       type='submit'
-                      className='absolute right-10 cursor-pointer text-xl text-primary-100 transition-all md:right-12'
+                      className='absolute right-9 cursor-pointer text-2xl text-primary-100 transition-all md:right-12'
                     >
                       <RiSendPlaneFill />
                     </button>


### PR DESCRIPTION
disables message input when a message is sent and displays the following buttons: `Send again` & `Create your own link`

<img width="570" alt="image" src="https://user-images.githubusercontent.com/78056869/179349827-cd27d10c-5e0d-4695-b648-c2f01a1f1de1.png">
