### PR TITLE
RC: v7.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ any that are empty.
 
 - Tapping a profile picture or @username now opens that profile everywhere — the feed, comments, notes, group member lists, group chat, reaction lists, and follower lists. Previously only the display name was clickable, and in the feed a tap on the avatar opened the post instead.
 - Closing the post composer with unsent writing, images, or a poll now asks before discarding the draft.
-- Removing a group member and clearing your note now ask for confirmation first.
+- Removing a group member, deleting a group chat message, and clearing your note now ask for confirmation first.
 - Like, repost, comment, and card-menu controls are easier to tap on phones without the cards getting any taller.
 - Tapping the Feed or Notes tab you're already on scrolls the list back to the top.
 - The group chat message box grows as you write multiple lines instead of scrolling inside a single-line box.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,34 @@ any that are empty.
 - **Deprecated** — features marked for removal.
 - **Removed** — features removed.
 
+## [7.4.0] - 2026-08-05
+
+### Added
+
+- Group chat shows a "new messages" button when messages arrive while you're scrolled up — tap it to jump to the latest.
+- New notifications are marked with a dot, so you can tell what arrived since your last visit.
+- Character counters appear as you approach the length limit in the notes composer, group chat, and the bio and custom message fields in settings.
+- The Account and Privacy settings tabs have their own links, so they can be shared and the back button undoes a tab switch.
+
+### Changed
+
+- Tapping a profile picture or @username now opens that profile everywhere — the feed, comments, notes, group member lists, group chat, reaction lists, and follower lists. Previously only the display name was clickable, and in the feed a tap on the avatar opened the post instead.
+- Closing the post composer with unsent writing, images, or a poll now asks before discarding the draft.
+- Removing a group member and clearing your note now ask for confirmation first.
+- Like, repost, comment, and card-menu controls are easier to tap on phones without the cards getting any taller.
+- Tapping the Feed or Notes tab you're already on scrolls the list back to the top.
+- The group chat message box grows as you write multiple lines instead of scrolling inside a single-line box.
+- Hovering any timestamp now shows the exact date and time, on every card and page.
+- The recipient's name on the anonymous send page links to their profile, so you can check who you're writing to.
+- Pressing Enter in the song-link dialog attaches the song.
+
+### Fixed
+
+- The comment count beside the comment icon now opens the post, matching the icon next to it.
+- Sharing a post now confirms "link copied" on browsers without a share menu; before, it copied silently and looked like nothing happened.
+- Replying from the inbox can no longer double-send while the first attempt is still in flight.
+- Approving, rejecting, or removing one group member no longer disables the buttons on every other member's row.
+
 ## [7.3.0] - 2026-07-29
 
 ### Added
@@ -883,6 +911,7 @@ Turso query cost, and a set of audit-driven correctness and security fixes.
 - Stopped logging raw errors that could contain usernames or token internals.
 - Added a daily cron that prunes expired sessions.
 
+[7.4.0]: https://github.com/omsimos/umamin/compare/v7.3.0...v7.4.0
 [7.3.0]: https://github.com/omsimos/umamin/compare/v7.2.0...v7.3.0
 [7.2.0]: https://github.com/omsimos/umamin/compare/v7.1.0...v7.2.0
 [7.1.0]: https://github.com/omsimos/umamin/compare/v7.0.0...v7.1.0

--- a/apps/web/src/components/account-sheet.tsx
+++ b/apps/web/src/components/account-sheet.tsx
@@ -25,7 +25,7 @@ import {
 import { toast } from "sonner";
 import { GroupBadge } from "@/components/group-badge";
 import { ThemeToggleButton } from "@/components/theme-toggle-button";
-import { callAction } from "@/lib/api";
+import { actionError, callAction } from "@/lib/api";
 import { umaminChatUrl } from "@/lib/chat-link";
 import { Link, useAppNavigate } from "@/lib/navigation";
 import {
@@ -56,7 +56,14 @@ export function AccountSheet({
   // logout redirects server-side; the client clears its cache and navigates to
   // /login (session cookie already invalidated).
   const logoutMutation = useMutation({
-    mutationFn: () => callAction("logout"),
+    // callAction never rejects — it returns { error } — so throw here or
+    // onError is unreachable and a failed logout would still "succeed".
+    mutationFn: async () => {
+      const res = await callAction("logout");
+      const err = actionError(res);
+      if (err) throw new Error(err);
+      return res;
+    },
     onSuccess: () => {
       queryClient.clear();
       navigate("/login");

--- a/apps/web/src/components/account-sheet.tsx
+++ b/apps/web/src/components/account-sheet.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Avatar,
   AvatarFallback,
@@ -16,11 +16,13 @@ import { cn } from "@umamin/ui/lib/utils";
 import {
   CircleFadingPlusIcon,
   CircleUserRoundIcon,
+  Loader2Icon,
   LogOutIcon,
   MessageSquareQuoteIcon,
   SettingsIcon,
   UsersRoundIcon,
 } from "lucide-react";
+import { toast } from "sonner";
 import { GroupBadge } from "@/components/group-badge";
 import { ThemeToggleButton } from "@/components/theme-toggle-button";
 import { callAction } from "@/lib/api";
@@ -50,6 +52,18 @@ export function AccountSheet({
   const queryClient = useQueryClient();
   const navigate = useAppNavigate();
   const version = import.meta.env.VITE_APP_VERSION ?? "v0.0.0";
+
+  // logout redirects server-side; the client clears its cache and navigates to
+  // /login (session cookie already invalidated).
+  const logoutMutation = useMutation({
+    mutationFn: () => callAction("logout"),
+    onSuccess: () => {
+      queryClient.clear();
+      navigate("/login");
+    },
+    onError: () => toast.error("Couldn't log out. Please try again."),
+  });
+
   const { data } = useQuery({
     queryKey: queryKeys.currentUser(),
     queryFn: fetchCurrentUserOptional,
@@ -182,16 +196,15 @@ export function AccountSheet({
           <div className="border-t pt-4">
             <button
               type="button"
-              onClick={async () => {
-                // logout redirects server-side; the client clears its cache and
-                // navigates to /login (session cookie already invalidated).
-                await callAction("logout");
-                queryClient.clear();
-                navigate("/login");
-              }}
-              className="flex w-full items-center gap-4 py-2 text-muted-foreground transition-colors hover:text-foreground"
+              disabled={logoutMutation.isPending}
+              onClick={() => logoutMutation.mutate()}
+              className="flex w-full items-center gap-4 py-2 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
             >
-              <LogOutIcon className="size-5" />
+              {logoutMutation.isPending ? (
+                <Loader2Icon className="size-5 animate-spin" />
+              ) : (
+                <LogOutIcon className="size-5" />
+              )}
               Log out
             </button>
           </div>

--- a/apps/web/src/components/compose-dialog.tsx
+++ b/apps/web/src/components/compose-dialog.tsx
@@ -15,7 +15,7 @@ import {
   AvatarImage,
 } from "@umamin/ui/components/avatar";
 import { Badge } from "@umamin/ui/components/badge";
-import { Button } from "@umamin/ui/components/button";
+import { Button, buttonVariants } from "@umamin/ui/components/button";
 import {
   Dialog,
   DialogContent,
@@ -394,10 +394,13 @@ export function ComposeDialog({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Keep editing</AlertDialogCancel>
-            <AlertDialogAction asChild>
-              <Button variant="destructive" onClick={discardDraft}>
-                Discard
-              </Button>
+            {/* buttonVariants className, not asChild — Slot's class merge lets
+                the Action's default variant win over a nested Button's. */}
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={discardDraft}
+            >
+              Discard
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/components/compose-dialog.tsx
+++ b/apps/web/src/components/compose-dialog.tsx
@@ -1,5 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@umamin/ui/components/alert-dialog";
+import {
   Avatar,
   AvatarFallback,
   AvatarImage,
@@ -66,6 +76,7 @@ export function ComposeDialog({
 
   const [dragging, setDragging] = useState(false);
   const [content, setContent] = useState("");
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
   const [poll, setPoll] = useState<{
     options: string[];
     duration: PollDuration;
@@ -158,8 +169,29 @@ export function ComposeDialog({
     attachments.addFiles(files);
   };
 
+  // Escape, the overlay, and the X all route through here — a dirty draft
+  // (words, images, or a poll) asks before it's thrown away.
+  const isDirty =
+    content.trim().length > 0 || attachments.items.length > 0 || poll !== null;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && isDirty) {
+      setConfirmDiscard(true);
+      return;
+    }
+    onOpenChange(next);
+  };
+
+  const discardDraft = () => {
+    setConfirmDiscard(false);
+    setContent("");
+    setPoll(null);
+    attachments.discardAll();
+    onOpenChange(false);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         showCloseButton={false}
         className="flex h-dvh max-w-xl flex-col gap-0 p-0 sm:h-auto sm:max-h-[80dvh] sm:rounded-xl"
@@ -202,7 +234,7 @@ export function ComposeDialog({
               type="button"
               variant="ghost"
               size="icon"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleOpenChange(false)}
               aria-label="Cancel"
             >
               <XIcon />
@@ -351,6 +383,25 @@ export function ComposeDialog({
           </footer>
         </form>
       </DialogContent>
+
+      <AlertDialog open={confirmDiscard} onOpenChange={setConfirmDiscard}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard this post?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your draft will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep editing</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button variant="destructive" onClick={discardDraft}>
+                Discard
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   );
 }

--- a/apps/web/src/components/follow-list-drawer.tsx
+++ b/apps/web/src/components/follow-list-drawer.tsx
@@ -409,9 +409,12 @@ function FollowUserRow({
           )}
           <GroupBadge badge={user.groupBadge} />
         </div>
-        <p className="truncate text-muted-foreground text-sm">
+        <Link
+          href={`/user/${user.username}`}
+          className="block truncate text-muted-foreground text-sm hover:underline"
+        >
           @{user.username}
-        </p>
+        </Link>
       </div>
 
       {!isSelf ? (

--- a/apps/web/src/components/menu.tsx
+++ b/apps/web/src/components/menu.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@umamin/ui/components/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -5,8 +6,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@umamin/ui/components/dropdown-menu";
+import { EllipsisVerticalIcon } from "lucide-react";
 import React from "react";
-import { Icons } from "@/lib/icons";
 
 export type MenuItems = {
   title: string;
@@ -19,8 +20,17 @@ export type MenuItems = {
 export const Menu = ({ menuItems }: { menuItems: MenuItems }) => {
   return (
     <DropdownMenu modal={false}>
-      <DropdownMenuTrigger aria-label="More options">
-        <Icons.elipsisVertical />
+      <DropdownMenuTrigger asChild>
+        {/* 32px tap target inside a 24px layout box so card rows keep their
+            height. */}
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="More options"
+          className="size-8 -m-1"
+        >
+          <EllipsisVerticalIcon className="size-5" />
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         {menuItems.map((item, i) => (

--- a/apps/web/src/components/menubar-link.tsx
+++ b/apps/web/src/components/menubar-link.tsx
@@ -25,6 +25,14 @@ export function MenubarLink({
       aria-label={ariaLabel}
       aria-current={active ? "page" : undefined}
       className={cn(active && "text-foreground!")}
+      onClick={(e) => {
+        // Re-tapping the current tab scrolls back to the top of the list
+        // instead of a no-op navigation.
+        if (active) {
+          e.preventDefault();
+          window.scrollTo({ top: 0, behavior: "smooth" });
+        }
+      }}
     >
       {children}
     </Link>

--- a/apps/web/src/components/quoted-post-card.tsx
+++ b/apps/web/src/components/quoted-post-card.tsx
@@ -6,9 +6,9 @@ import {
 import { cn } from "@umamin/ui/lib/utils";
 import { BarChart3Icon, ScanFaceIcon } from "lucide-react";
 import { PostImages } from "@/components/post-images";
+import { TimeAgo } from "@/components/time-ago";
 import { Link } from "@/lib/navigation";
 import type { QuotedPostData } from "@/lib/types";
-import { shortTimeAgo } from "@/lib/utils";
 
 type Props = {
   /** null = quoted post deleted or hidden from this viewer (husk). */
@@ -52,9 +52,10 @@ export function QuotedPostCard({ post, linked = true, className }: Props) {
         <span className="truncate text-muted-foreground">
           @{post.author.username}
         </span>
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {shortTimeAgo(post.createdAt)}
-        </span>
+        <TimeAgo
+          date={post.createdAt}
+          className="shrink-0 text-xs text-muted-foreground"
+        />
       </div>
 
       {post.content && (

--- a/apps/web/src/components/song-attach-dialog.tsx
+++ b/apps/web/src/components/song-attach-dialog.tsx
@@ -101,7 +101,13 @@ function SongForm({
   };
 
   return (
-    <div className="space-y-4">
+    <form
+      className="space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (music) onAttach(trimmed);
+      }}
+    >
       <div className="flex items-center gap-2">
         <div className="relative flex-1">
           <Music2Icon
@@ -117,6 +123,7 @@ function SongForm({
           <Input
             type="url"
             inputMode="url"
+            enterKeyHint="done"
             autoFocus
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -161,14 +168,10 @@ function SongForm({
         <Button type="button" variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
-        <Button
-          type="button"
-          disabled={!music}
-          onClick={() => music && onAttach(trimmed)}
-        >
+        <Button type="submit" disabled={!music}>
           Attach song
         </Button>
       </div>
-    </div>
+    </form>
   );
 }

--- a/apps/web/src/components/time-ago-verbose.tsx
+++ b/apps/web/src/components/time-ago-verbose.tsx
@@ -1,0 +1,33 @@
+import { formatDistanceToNow } from "date-fns";
+
+const exactTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+// Sentence-form sibling of TimeAgo ("about 2 hours ago") for prose contexts
+// like "Joined …" or "blocked …". Its own module so the hot list bundles that
+// use TimeAgo don't pull date-fns along.
+export function TimeAgoVerbose({
+  date,
+  className,
+}: {
+  date: Date | string;
+  className?: string;
+}) {
+  const d = typeof date === "string" ? new Date(date) : date;
+
+  if (Number.isNaN(d.getTime())) {
+    return null;
+  }
+
+  return (
+    <time
+      dateTime={d.toISOString()}
+      title={exactTimeFormatter.format(d)}
+      className={className}
+    >
+      {formatDistanceToNow(d, { addSuffix: true })}
+    </time>
+  );
+}

--- a/apps/web/src/components/user-card.tsx
+++ b/apps/web/src/components/user-card.tsx
@@ -6,7 +6,6 @@ import {
 import { Badge } from "@umamin/ui/components/badge";
 import { Button } from "@umamin/ui/components/button";
 import { cn } from "@umamin/ui/lib/utils";
-import { formatDistanceToNow } from "date-fns";
 import {
   BadgeCheckIcon,
   CalendarDaysIcon,
@@ -16,6 +15,7 @@ import {
   ShieldUserIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
+import { TimeAgoVerbose } from "@/components/time-ago-verbose";
 import { Link } from "@/lib/navigation";
 import type { PublicUserWithBadge } from "@/lib/types";
 import { hasUmaminPlus } from "@/lib/utils";
@@ -158,10 +158,9 @@ export function UserCard({
 
             <div className="text-muted-foreground text-sm flex items-center gap-2">
               <CalendarDaysIcon className="size-4" />
-              Joined{" "}
-              {formatDistanceToNow(user.createdAt, {
-                addSuffix: true,
-              })}
+              <span>
+                Joined <TimeAgoVerbose date={user.createdAt} />
+              </span>
             </div>
           </div>
 

--- a/apps/web/src/hooks/use-image-attachments.ts
+++ b/apps/web/src/hooks/use-image-attachments.ts
@@ -226,6 +226,21 @@ export function useImageAttachments() {
     setItems([]);
   };
 
+  // Draft discarded without posting: unlike resetAfterPost, nothing downstream
+  // renders the previews, so abort in-flight uploads and revoke them.
+  const discardAll = () => {
+    for (const meta of metaRef.current.values()) {
+      meta.xhr?.abort();
+    }
+    metaRef.current.clear();
+    setItems((prev) => {
+      for (const item of prev) {
+        URL.revokeObjectURL(item.previewUrl);
+      }
+      return [];
+    });
+  };
+
   const isBusy = items.some(
     (item) => item.status === "processing" || item.status === "uploading",
   );
@@ -247,6 +262,7 @@ export function useImageAttachments() {
     remove,
     retry,
     resetAfterPost,
+    discardAll,
     isBusy,
     hasReadyImages,
     hasErrors,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -321,6 +321,9 @@ export type NotificationItem = {
 export type NotificationsResponse = {
   notifications: NotificationItem[];
   nextCursor: string | null;
+  // Viewer's seen watermark (ms since epoch, 0 = never seen any), present on
+  // the first page only. Items with updatedAt beyond it render as new.
+  lastSeen?: number;
 };
 
 export type NotificationBadgeResponse = {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -266,8 +266,10 @@ export const sharePost = (postId: string) => {
       ) {
         navigator.share({ url });
       } else {
-        navigator.clipboard.writeText(url);
-        toast.success("Post link copied.");
+        navigator.clipboard
+          .writeText(url)
+          .then(() => toast.success("Post link copied."))
+          .catch(() => toast.error("Couldn't copy the link."));
       }
     }
   } catch (err) {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -267,6 +267,7 @@ export const sharePost = (postId: string) => {
         navigator.share({ url });
       } else {
         navigator.clipboard.writeText(url);
+        toast.success("Post link copied.");
       }
     }
   } catch (err) {

--- a/apps/web/src/routes/-chat/group-chat.tsx
+++ b/apps/web/src/routes/-chat/group-chat.tsx
@@ -5,6 +5,16 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@umamin/ui/components/alert-dialog";
+import {
   Avatar,
   AvatarFallback,
   AvatarImage,
@@ -133,6 +143,8 @@ export function GroupChat({
   );
   // Others' messages that arrived while scrolled up — drives the jump pill.
   const [unseen, setUnseen] = useState(0);
+  // Message pending delete confirmation (one shared dialog, not one per row).
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const composerRef = useDynamicTextarea(draft);
   const scrollRef = useRef<HTMLDivElement>(null);
   const nearBottomRef = useRef(true);
@@ -436,6 +448,9 @@ export function GroupChat({
     setDraft("");
     setReplyingTo(null);
     nearBottomRef.current = true;
+    // Sending jumps to the bottom — don't leave the pill over the fresh bubble
+    // while the programmatic scroll event catches up.
+    setUnseen(0);
 
     submitMessage(tempId, content, parent?.id ?? null);
   };
@@ -674,7 +689,7 @@ export function GroupChat({
                           {canDelete && (
                             <DropdownMenuItem
                               variant="destructive"
-                              onSelect={() => deleteMutation.mutate(message.id)}
+                              onSelect={() => setDeleteTarget(message.id)}
                             >
                               <Trash2Icon /> Delete
                             </DropdownMenuItem>
@@ -815,6 +830,33 @@ export function GroupChat({
         currentUserId={currentUserId}
         onClose={() => setReactorsMessageId(null)}
       />
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this message?</AlertDialogTitle>
+            <AlertDialogDescription>
+              It's removed for everyone in the group.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deleteTarget) deleteMutation.mutate(deleteTarget);
+                setDeleteTarget(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/src/routes/-chat/group-chat.tsx
+++ b/apps/web/src/routes/-chat/group-chat.tsx
@@ -19,6 +19,7 @@ import {
 } from "@umamin/ui/components/dropdown-menu";
 import { cn } from "@umamin/ui/lib/utils";
 import {
+  ArrowDownIcon,
   ArrowLeftIcon,
   Loader2Icon,
   ReplyIcon,
@@ -37,6 +38,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { GroupBadge } from "@/components/group-badge";
+import { useDynamicTextarea } from "@/hooks/use-dynamic-textarea";
 import {
   GROUP_CHAT_REACTION_EMOJIS,
   type GroupAccent,
@@ -72,6 +74,7 @@ import { ReactionsDrawer } from "./reactions-drawer";
 // billed edge request. Keep aligned with the head route's cache TTL.
 const HEAD_POLL_MS = 8000;
 const GROUP_MESSAGE_MAX = 1000;
+const COUNTER_VISIBLE_AT = 900;
 const EMPTY_CURSOR = "0.";
 const MENTION_SPLIT = /(@[a-z0-9_-]+)/gi;
 const MENTION_TEST = /^@[a-z0-9_-]+$/i;
@@ -128,6 +131,9 @@ export function GroupChat({
   const [reactorsMessageId, setReactorsMessageId] = useState<string | null>(
     null,
   );
+  // Others' messages that arrived while scrolled up — drives the jump pill.
+  const [unseen, setUnseen] = useState(0);
+  const composerRef = useDynamicTextarea(draft);
   const scrollRef = useRef<HTMLDivElement>(null);
   const nearBottomRef = useRef(true);
   const lastRxnRef = useRef<number | null>(null);
@@ -218,6 +224,12 @@ export function GroupChat({
         if (delta.data.length > 0) {
           setLive((prev) => mergeById(prev, delta.data));
           void loadReactions(delta.data.map((m) => m.id));
+          if (!nearBottomRef.current) {
+            const arrived = delta.data.filter(
+              (m) => m.sender.id !== currentUserId,
+            ).length;
+            if (arrived > 0) setUnseen((c) => c + arrived);
+          }
         }
       }
 
@@ -449,6 +461,16 @@ export function GroupChat({
     if (!el) return;
     nearBottomRef.current =
       el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    if (nearBottomRef.current) {
+      setUnseen((c) => (c === 0 ? c : 0));
+    }
+  };
+
+  const jumpToLatest = () => {
+    const el = scrollRef.current;
+    if (el) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    nearBottomRef.current = true;
+    setUnseen(0);
   };
 
   const GroupIconGlyph =
@@ -710,6 +732,22 @@ export function GroupChat({
           })}
         </div>
 
+        {unseen > 0 && (
+          // Zero-height anchor so the pill floats over the list bottom without
+          // shifting the composer.
+          <div className="relative shrink-0">
+            <Button
+              type="button"
+              size="sm"
+              onClick={jumpToLatest}
+              className="-top-12 -translate-x-1/2 absolute left-1/2 z-10 rounded-full shadow-lg"
+            >
+              <ArrowDownIcon className="size-4" />
+              {unseen === 1 ? "1 new message" : `${unseen} new messages`}
+            </Button>
+          </div>
+        )}
+
         {replyingTo && (
           <div className="flex shrink-0 items-center gap-2 border-t px-2 pt-2 text-xs text-muted-foreground">
             <ReplyIcon className="size-3.5 shrink-0" />
@@ -733,6 +771,12 @@ export function GroupChat({
           </div>
         )}
 
+        {draft.length >= COUNTER_VISIBLE_AT && (
+          <p className="shrink-0 px-4 pt-1 text-right text-muted-foreground text-xs tabular-nums">
+            {GROUP_MESSAGE_MAX - draft.length} left
+          </p>
+        )}
+
         <form
           className="flex shrink-0 items-end gap-2 border-t px-2 pt-3"
           style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
@@ -742,12 +786,15 @@ export function GroupChat({
           }}
         >
           <textarea
+            ref={composerRef}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={onKeyDown}
             rows={1}
             maxLength={GROUP_MESSAGE_MAX}
             placeholder="Message…"
+            aria-label="Message"
+            autoComplete="off"
             className="max-h-32 min-h-11 flex-1 resize-none rounded-2xl border bg-muted/40 px-4 py-2.5 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
           />
           <Button

--- a/apps/web/src/routes/-chat/group-chat.tsx
+++ b/apps/web/src/routes/-chat/group-chat.tsx
@@ -572,9 +572,12 @@ export function GroupChat({
                 >
                   {!isOwn && firstOfGroup && (
                     <div className="flex min-w-0 items-center gap-1.5 pb-0.5">
-                      <span className="truncate text-xs font-medium">
+                      <Link
+                        href={`/user/${message.sender.username}`}
+                        className="truncate text-xs font-medium hover:underline"
+                      >
                         {message.sender.displayName ?? message.sender.username}
-                      </span>
+                      </Link>
                       <GroupBadge badge={message.sender.groupBadge} />
                       <span className="shrink-0 text-[10px] whitespace-nowrap text-muted-foreground">
                         {timeFormat.format(new Date(message.createdAt))}

--- a/apps/web/src/routes/-chat/reactions-drawer.tsx
+++ b/apps/web/src/routes/-chat/reactions-drawer.tsx
@@ -20,6 +20,7 @@ import {
 } from "@umamin/ui/components/drawer";
 import { Loader2Icon, ScanFaceIcon } from "lucide-react";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { Link } from "@/lib/navigation";
 import { fetchGroupMessageReactors } from "@/lib/query-fetchers";
 import type { GroupMessageReactor } from "@/lib/types";
 
@@ -55,18 +56,27 @@ function ReactorList({
           key={`${r.user.id}-${r.emoji}`}
           className="flex items-center gap-3 py-1.5"
         >
-          <Avatar className="size-9">
-            <AvatarImage src={r.user.imageUrl ?? ""} alt="" />
-            <AvatarFallback>
-              <ScanFaceIcon className="size-4" />
-            </AvatarFallback>
-          </Avatar>
-          <span className="min-w-0 flex-1 truncate text-sm font-medium">
+          <Link
+            href={`/user/${r.user.username}`}
+            aria-label={`@${r.user.username}'s profile`}
+            className="shrink-0"
+          >
+            <Avatar className="size-9">
+              <AvatarImage src={r.user.imageUrl ?? ""} alt="" />
+              <AvatarFallback>
+                <ScanFaceIcon className="size-4" />
+              </AvatarFallback>
+            </Avatar>
+          </Link>
+          <Link
+            href={`/user/${r.user.username}`}
+            className="min-w-0 flex-1 truncate text-sm font-medium hover:underline"
+          >
             {r.user.displayName ?? r.user.username}
             {r.user.id === currentUserId && (
               <span className="font-normal text-muted-foreground"> (you)</span>
             )}
-          </span>
+          </Link>
           <span aria-hidden className="text-xl leading-none">
             {r.emoji}
           </span>

--- a/apps/web/src/routes/-groups/group-page-client.tsx
+++ b/apps/web/src/routes/-groups/group-page-client.tsx
@@ -40,7 +40,6 @@ import {
 } from "@umamin/ui/components/dropdown-menu";
 import { Input } from "@umamin/ui/components/input";
 import { cn } from "@umamin/ui/lib/utils";
-import { formatDistanceToNow } from "date-fns";
 import {
   CheckIcon,
   EllipsisIcon,
@@ -59,6 +58,7 @@ import {
 import { type FormEventHandler, useState } from "react";
 import { toast } from "sonner";
 import { GroupEditDialog } from "@/components/group-edit-dialog";
+import { TimeAgoVerbose } from "@/components/time-ago-verbose";
 import { useSingleFlightAction } from "@/hooks/use-single-flight-action";
 import {
   GROUP_CHAT_ENABLED,
@@ -383,8 +383,7 @@ export function GroupPageClient({
           </p>
           {group.creator && (
             <p className="text-xs text-muted-foreground">
-              Created{" "}
-              {formatDistanceToNow(group.createdAt, { addSuffix: true })} by{" "}
+              Created <TimeAgoVerbose date={group.createdAt} /> by{" "}
               <Link
                 href={`/user/${group.creator.username}`}
                 className="hover:underline"
@@ -691,20 +690,41 @@ export function GroupPageClient({
                     Owner
                   </Badge>
                 ) : isOwner && member.user.id !== currentUserId ? (
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    aria-label={`Remove ${member.user.username}`}
-                    disabled={
-                      kickMutation.isPending &&
-                      kickMutation.variables === member.user.id
-                    }
-                    onClick={() => kickMutation.mutate(member.user.id)}
-                    className="text-muted-foreground hover:text-destructive"
-                  >
-                    <UserMinusIcon className="size-4" />
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        aria-label={`Remove ${member.user.username}`}
+                        disabled={
+                          kickMutation.isPending &&
+                          kickMutation.variables === member.user.id
+                        }
+                        className="text-muted-foreground hover:text-destructive"
+                      >
+                        <UserMinusIcon className="size-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>
+                          Remove @{member.user.username}?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          They'll lose access to the group and its chat.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => kickMutation.mutate(member.user.id)}
+                        >
+                          Remove
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 ) : null}
               </li>
             ))}

--- a/apps/web/src/routes/-groups/group-page-client.tsx
+++ b/apps/web/src/routes/-groups/group-page-client.tsx
@@ -564,12 +564,18 @@ export function GroupPageClient({
           <ul className="divide-y">
             {requestRows.map((request) => (
               <li key={request.id} className="flex items-center gap-3 py-3">
-                <Avatar className="size-9">
-                  <AvatarImage src={request.user.imageUrl ?? ""} alt="" />
-                  <AvatarFallback>
-                    <ScanFaceIcon className="size-4" />
-                  </AvatarFallback>
-                </Avatar>
+                <Link
+                  href={`/user/${request.user.username}`}
+                  aria-label={`@${request.user.username}'s profile`}
+                  className="shrink-0"
+                >
+                  <Avatar className="size-9">
+                    <AvatarImage src={request.user.imageUrl ?? ""} alt="" />
+                    <AvatarFallback>
+                      <ScanFaceIcon className="size-4" />
+                    </AvatarFallback>
+                  </Avatar>
+                </Link>
                 <Link
                   href={`/user/${request.user.username}`}
                   className="min-w-0 flex-1"
@@ -586,7 +592,10 @@ export function GroupPageClient({
                   size="icon"
                   variant="ghost"
                   aria-label={`Approve ${request.user.username}`}
-                  disabled={respondRequestMutation.isPending}
+                  disabled={
+                    respondRequestMutation.isPending &&
+                    respondRequestMutation.variables?.userId === request.user.id
+                  }
                   onClick={() =>
                     respondRequestMutation.mutate({
                       userId: request.user.id,
@@ -602,7 +611,10 @@ export function GroupPageClient({
                   size="icon"
                   variant="ghost"
                   aria-label={`Reject ${request.user.username}`}
-                  disabled={respondRequestMutation.isPending}
+                  disabled={
+                    respondRequestMutation.isPending &&
+                    respondRequestMutation.variables?.userId === request.user.id
+                  }
                   onClick={() =>
                     respondRequestMutation.mutate({
                       userId: request.user.id,
@@ -651,12 +663,18 @@ export function GroupPageClient({
           <ul className="divide-y">
             {memberRows.map((member) => (
               <li key={member.id} className="flex items-center gap-3 py-3">
-                <Avatar className="size-9">
-                  <AvatarImage src={member.user.imageUrl ?? ""} alt="" />
-                  <AvatarFallback>
-                    <ScanFaceIcon className="size-4" />
-                  </AvatarFallback>
-                </Avatar>
+                <Link
+                  href={`/user/${member.user.username}`}
+                  aria-label={`@${member.user.username}'s profile`}
+                  className="shrink-0"
+                >
+                  <Avatar className="size-9">
+                    <AvatarImage src={member.user.imageUrl ?? ""} alt="" />
+                    <AvatarFallback>
+                      <ScanFaceIcon className="size-4" />
+                    </AvatarFallback>
+                  </Avatar>
+                </Link>
                 <Link
                   href={`/user/${member.user.username}`}
                   className="min-w-0 flex-1"
@@ -678,7 +696,10 @@ export function GroupPageClient({
                     size="icon"
                     variant="ghost"
                     aria-label={`Remove ${member.user.username}`}
-                    disabled={kickMutation.isPending}
+                    disabled={
+                      kickMutation.isPending &&
+                      kickMutation.variables === member.user.id
+                    }
                     onClick={() => kickMutation.mutate(member.user.id)}
                     className="text-muted-foreground hover:text-destructive"
                   >

--- a/apps/web/src/routes/-inbox/received-card.tsx
+++ b/apps/web/src/routes/-inbox/received-card.tsx
@@ -5,6 +5,7 @@ import { cn } from "@umamin/ui/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { MailIcon } from "lucide-react";
 import { useState } from "react";
+import { TimeAgoVerbose } from "@/components/time-ago-verbose";
 import { vibrate } from "@/lib/haptics";
 import { queryKeys } from "@/lib/query";
 import { patchMessage } from "@/lib/query-cache";
@@ -74,7 +75,7 @@ export function ReceivedMessageCard({ data }: { data: MessageWithReceiver }) {
         <span className="font-semibold">{sealedTitleFor(data.id)}</span>
         <span className="text-muted-foreground text-sm">Tap to open</span>
         <span className="mt-2 text-muted-foreground text-xs italic">
-          {receivedAgo}
+          <TimeAgoVerbose date={data.createdAt} />
         </span>
       </Button>
     );
@@ -105,9 +106,7 @@ export function ReceivedMessageCard({ data }: { data: MessageWithReceiver }) {
           {data.content}
         </div>
         <p className="text-muted-foreground text-sm mt-4 italic text-center">
-          {formatDistanceToNow(data.createdAt, {
-            addSuffix: true,
-          })}
+          <TimeAgoVerbose date={data.createdAt} />
         </p>
 
         {(data.reply || data.lastReplyAt) && (

--- a/apps/web/src/routes/-inbox/reply-dialog.tsx
+++ b/apps/web/src/routes/-inbox/reply-dialog.tsx
@@ -125,7 +125,7 @@ export function ReplyDialog(props: Props) {
                 className="focus-visible:ring-transparent flex-1 text-base resize-none min-h-10 max-h-20"
                 autoComplete="off"
               />
-              <Button type="submit" size="icon">
+              <Button type="submit" size="icon" disabled={mutation.isPending}>
                 {mutation.isPending ? (
                   <Loader2Icon className="w-4 h-4 animate-spin" />
                 ) : (

--- a/apps/web/src/routes/-inbox/reply-dialog.tsx
+++ b/apps/web/src/routes/-inbox/reply-dialog.tsx
@@ -8,11 +8,11 @@ import {
   DialogTitle,
 } from "@umamin/ui/components/dialog";
 import { Textarea } from "@umamin/ui/components/textarea";
-import { formatDistanceToNow } from "date-fns";
 import { Loader2Icon, SendIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ChatList } from "@/components/chat-list";
+import { TimeAgoVerbose } from "@/components/time-ago-verbose";
 import { useDynamicTextarea } from "@/hooks/use-dynamic-textarea";
 import { useSingleFlightAction } from "@/hooks/use-single-flight-action";
 import { queryKeys } from "@/lib/query";
@@ -97,10 +97,7 @@ export function ReplyDialog(props: Props) {
 
             {reply && updatedAt && (
               <div className="text-muted-foreground text-sm italic w-full text-center mt-10">
-                replied{" "}
-                {formatDistanceToNow(updatedAt, {
-                  addSuffix: true,
-                })}
+                replied <TimeAgoVerbose date={updatedAt} />
               </div>
             )}
           </div>

--- a/apps/web/src/routes/-inbox/sent-card.tsx
+++ b/apps/web/src/routes/-inbox/sent-card.tsx
@@ -4,9 +4,9 @@ import {
   CardFooter,
   CardHeader,
 } from "@umamin/ui/components/card";
-import { formatDistanceToNow } from "date-fns";
 import { CircleUserIcon } from "lucide-react";
 import { ChatList } from "@/components/chat-list";
+import { TimeAgoVerbose } from "@/components/time-ago-verbose";
 import { Link } from "@/lib/navigation";
 import type { MessageWithReceiver } from "@/lib/types";
 import { ThreadLink } from "./thread-link";
@@ -39,9 +39,7 @@ export function SentMessageCard({ data }: { data: MessageWithReceiver }) {
       </CardContent>
       <CardFooter className="flex flex-col items-stretch">
         <p className="text-center text-muted-foreground text-sm italic">
-          {formatDistanceToNow(data.createdAt, {
-            addSuffix: true,
-          })}
+          <TimeAgoVerbose date={data.createdAt} />
         </p>
         {(data.reply || data.lastReplyAt) && (
           <ThreadLink

--- a/apps/web/src/routes/-notifications/notification-card.tsx
+++ b/apps/web/src/routes/-notifications/notification-card.tsx
@@ -41,8 +41,10 @@ function notificationHref(notification: NotificationItem): string | null {
 
 export function NotificationCard({
   notification,
+  isNew,
 }: {
   notification: NotificationItem;
+  isNew?: boolean;
 }) {
   const { actor, type, count, preview, updatedAt } = notification;
   const actorName = actor ? (actor.displayName ?? actor.username) : null;
@@ -70,6 +72,13 @@ export function NotificationCard({
         ) : null}
         <TimeAgo date={updatedAt} className="text-xs text-muted-foreground" />
       </div>
+
+      {isNew && (
+        <span className="shrink-0">
+          <span aria-hidden className="block size-2 rounded-full bg-pink-500" />
+          <span className="sr-only">New</span>
+        </span>
+      )}
     </div>
   );
 

--- a/apps/web/src/routes/-notifications/notifications-list.tsx
+++ b/apps/web/src/routes/-notifications/notifications-list.tsx
@@ -1,3 +1,4 @@
+import type { InfiniteData } from "@tanstack/react-query";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Alert,
@@ -6,7 +7,7 @@ import {
 } from "@umamin/ui/components/alert";
 import { Button } from "@umamin/ui/components/button";
 import { AlertCircleIcon, BellOffIcon } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { callAction } from "@/lib/api";
 import {
   infiniteQueryDefaults,
@@ -48,6 +49,15 @@ export function NotificationsList() {
   const newest = data?.pages[0]?.notifications[0];
   const seenThroughMs = newest ? new Date(newest.updatedAt).getTime() : null;
 
+  // Latch the first watermark this visit renders with, so the mark-seen cache
+  // patch below doesn't clear the dots out from under the open page.
+  const pageLastSeen = data?.pages[0]?.lastSeen;
+  const visitLastSeenRef = useRef<number | undefined>(undefined);
+  if (visitLastSeenRef.current === undefined && pageLastSeen !== undefined) {
+    visitLastSeenRef.current = pageLastSeen;
+  }
+  const lastSeen = visitLastSeenRef.current;
+
   useEffect(() => {
     if (seenThroughMs === null) {
       return;
@@ -58,6 +68,19 @@ export function NotificationsList() {
         queryClient.invalidateQueries({
           queryKey: queryKeys.notificationBadge(),
         });
+        // Advance the cached watermark too — the list itself isn't refetched
+        // on remount, so without this a revisit within gcTime re-lights rows
+        // this visit already showed as new.
+        queryClient.setQueryData<InfiniteData<NotificationsResponse>>(
+          queryKeys.notifications(),
+          (current) =>
+            current && {
+              ...current,
+              pages: current.pages.map((page, i) =>
+                i === 0 ? { ...page, lastSeen: seenThroughMs } : page,
+              ),
+            },
+        );
       })
       .catch(() => {});
   }, [seenThroughMs, queryClient]);
@@ -90,10 +113,6 @@ export function NotificationsList() {
       </Alert>
     );
   }
-
-  // Fetch-time watermark: the cached first page keeps the value from before
-  // the mark-seen effect advanced it, so new rows stay marked for the visit.
-  const lastSeen = data?.pages[0]?.lastSeen;
 
   return (
     <div>

--- a/apps/web/src/routes/-notifications/notifications-list.tsx
+++ b/apps/web/src/routes/-notifications/notifications-list.tsx
@@ -91,12 +91,22 @@ export function NotificationsList() {
     );
   }
 
+  // Fetch-time watermark: the cached first page keeps the value from before
+  // the mark-seen effect advanced it, so new rows stay marked for the visit.
+  const lastSeen = data?.pages[0]?.lastSeen;
+
   return (
     <div>
       <ul className="divide-y">
         {notifications.map((notification) => (
           <li key={notification.id}>
-            <NotificationCard notification={notification} />
+            <NotificationCard
+              notification={notification}
+              isNew={
+                lastSeen !== undefined &&
+                new Date(notification.updatedAt).getTime() > lastSeen
+              }
+            />
           </li>
         ))}
       </ul>

--- a/apps/web/src/routes/-settings/account-settings.tsx
+++ b/apps/web/src/routes/-settings/account-settings.tsx
@@ -16,13 +16,13 @@ import {
   CollapsibleTrigger,
 } from "@umamin/ui/components/collapsible";
 import { Label } from "@umamin/ui/components/label";
-import { formatDistanceToNow } from "date-fns";
 import {
   ChevronsUpDownIcon,
   KeyIcon,
   ScanFaceIcon,
   ShieldAlertIcon,
 } from "lucide-react";
+import { TimeAgoVerbose } from "@/components/time-ago-verbose";
 import type { UserWithAccount } from "@/lib/types";
 import { DangerSettings } from "./danger-settings";
 import { PasswordForm } from "./password-form";
@@ -50,10 +50,7 @@ export function AccountSettings({ user }: { user: UserWithAccount }) {
                 <p>{user.account.email}</p>
 
                 <p className="text-muted-foreground">
-                  Linked{" "}
-                  {formatDistanceToNow(user.account.createdAt, {
-                    addSuffix: true,
-                  })}
+                  Linked <TimeAgoVerbose date={user.account.createdAt} />
                 </p>
               </div>
             </CardHeader>

--- a/apps/web/src/routes/-settings/blocked-users-section.tsx
+++ b/apps/web/src/routes/-settings/blocked-users-section.tsx
@@ -12,9 +12,9 @@ import {
 import { Button } from "@umamin/ui/components/button";
 import { Label } from "@umamin/ui/components/label";
 import { Skeleton } from "@umamin/ui/components/skeleton";
-import { formatDistanceToNow } from "date-fns";
 import { ScanFaceIcon } from "lucide-react";
 import { toast } from "sonner";
+import { TimeAgoVerbose } from "@/components/time-ago-verbose";
 import { Link } from "@/lib/navigation";
 import {
   infiniteQueryDefaults,
@@ -126,9 +126,7 @@ export function BlockedUsersSection() {
                   </Link>
                   <p className="text-xs text-muted-foreground truncate">
                     @{user.username} · blocked{" "}
-                    {formatDistanceToNow(new Date(user.blockedAt), {
-                      addSuffix: true,
-                    })}
+                    <TimeAgoVerbose date={user.blockedAt} />
                   </p>
                 </div>
 

--- a/apps/web/src/routes/-settings/general-settings.tsx
+++ b/apps/web/src/routes/-settings/general-settings.tsx
@@ -141,6 +141,7 @@ export function GeneralSettings({ user }: { user: UserWithAccount }) {
             placeholder="Umamin"
             value={fields.displayName}
             disabled={mutation.isPending}
+            maxLength={20}
             onChange={(e) => set("displayName", e.target.value)}
           />
           {errors.displayName && (
@@ -158,6 +159,7 @@ export function GeneralSettings({ user }: { user: UserWithAccount }) {
               placeholder="umamin"
               value={fields.username}
               disabled={!user.account || mutation.isPending}
+              maxLength={20}
               onChange={(e) => set("username", e.target.value.toLowerCase())}
             />
             {errors.username && (
@@ -186,8 +188,14 @@ export function GeneralSettings({ user }: { user: UserWithAccount }) {
             className="min-h-[100px] resize-none"
             value={fields.question}
             disabled={mutation.isPending}
+            maxLength={150}
             onChange={(e) => set("question", e.target.value)}
           />
+          {fields.question.length >= 120 && (
+            <p className="text-right text-muted-foreground text-xs tabular-nums">
+              {150 - fields.question.length} left
+            </p>
+          )}
           {errors.question && (
             <p className="text-sm text-destructive">{errors.question}</p>
           )}
@@ -201,8 +209,14 @@ export function GeneralSettings({ user }: { user: UserWithAccount }) {
             className="min-h-[100px] resize-none"
             value={fields.bio}
             disabled={mutation.isPending}
+            maxLength={150}
             onChange={(e) => set("bio", e.target.value)}
           />
+          {fields.bio.length >= 120 && (
+            <p className="text-right text-muted-foreground text-xs tabular-nums">
+              {150 - fields.bio.length} left
+            </p>
+          )}
           {errors.bio && (
             <p className="text-sm text-destructive">{errors.bio}</p>
           )}

--- a/apps/web/src/routes/-settings/settings-tabs.tsx
+++ b/apps/web/src/routes/-settings/settings-tabs.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi, useNavigate } from "@tanstack/react-router";
 import {
   Tabs,
   TabsContent,
@@ -13,7 +14,13 @@ import { GeneralSettings } from "./general-settings";
 import { PrivacySettings } from "./privacy-settings";
 import { SettingsSkeleton } from "./settings-skeleton";
 
+const routeApi = getRouteApi("/_private/settings");
+
 export function SettingsTabs() {
+  // Tab lives in the URL so Account/Privacy are linkable and back undoes a
+  // tab switch. Absent = general.
+  const { tab } = routeApi.useSearch();
+  const navigate = useNavigate();
   const { data, isLoading } = useQuery({
     ...pageQueryOptions(queryKeys.currentUser(), fetchCurrentUser),
   });
@@ -30,7 +37,19 @@ export function SettingsTabs() {
   }, [data?.user]);
 
   return (
-    <Tabs defaultValue="general" className="w-full">
+    <Tabs
+      value={tab ?? "general"}
+      onValueChange={(value) =>
+        navigate({
+          to: ".",
+          search: (prev) => ({
+            ...prev,
+            tab: value === "account" || value === "privacy" ? value : undefined,
+          }),
+        })
+      }
+      className="w-full"
+    >
       <TabsList className="w-full bg-transparent px-0 flex mb-8">
         <TabsTrigger
           value="general"

--- a/apps/web/src/routes/_private.settings.tsx
+++ b/apps/web/src/routes/_private.settings.tsx
@@ -16,11 +16,17 @@ import { SettingsTabs } from "./-settings/settings-tabs";
 import { SignOutButton } from "./-settings/sign-out-button";
 import { BackHeaderPage } from "./-shared/chrome";
 
-type SettingsSearch = { error?: string };
+type SettingsSearch = { error?: string; tab?: "account" | "privacy" };
 
 export const Route = createFileRoute("/_private/settings")({
+  // `tab` stays optional with no materialized default (general) — see the
+  // /feed sort gotcha: emitting the default canonicalizes every bare URL.
   validateSearch: (search: Record<string, unknown>): SettingsSearch => ({
     error: typeof search.error === "string" ? search.error : undefined,
+    tab:
+      search.tab === "account" || search.tab === "privacy"
+        ? search.tab
+        : undefined,
   }),
   head: () =>
     pageSeo({

--- a/apps/web/src/routes/_social/-components/current-user-note.tsx
+++ b/apps/web/src/routes/_social/-components/current-user-note.tsx
@@ -1,10 +1,21 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@umamin/ui/components/alert-dialog";
+import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@umamin/ui/components/avatar";
 import { Badge } from "@umamin/ui/components/badge";
+import { Button } from "@umamin/ui/components/button";
 import {
   Card,
   CardContent,
@@ -23,22 +34,19 @@ import {
   ScanFaceIcon,
   ScrollIcon,
 } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { GroupBadge } from "@/components/group-badge";
 import { Menu } from "@/components/menu";
 import { MusicEmbed } from "@/components/music-embed";
 import { PostBody } from "@/components/post-body";
+import { TimeAgo } from "@/components/time-ago";
 import { Link } from "@/lib/navigation";
 import { pageQueryOptions, queryKeys } from "@/lib/query";
 import { patchNote } from "@/lib/query-cache";
 import { fetchCurrentNote } from "@/lib/query-fetchers";
 import type { NoteItem, NotesResponse, PublicUserWithBadge } from "@/lib/types";
-import {
-  getActionError,
-  hasUmaminPlus,
-  saveImage,
-  shortTimeAgo,
-} from "@/lib/utils";
+import { getActionError, hasUmaminPlus, saveImage } from "@/lib/utils";
 import { clearNoteAction } from "../-lib/actions";
 
 export function CurrentUserNote({
@@ -47,6 +55,7 @@ export function CurrentUserNote({
   currentUser: PublicUserWithBadge;
 }) {
   const queryClient = useQueryClient();
+  const [clearOpen, setClearOpen] = useState(false);
   const { data, isLoading } = useQuery<NoteItem | null>({
     ...pageQueryOptions(queryKeys.currentNote(), fetchCurrentNote),
   });
@@ -93,7 +102,7 @@ export function CurrentUserNote({
     },
     {
       title: "Clear Note",
-      onClick: () => clearNoteMutation.mutate(),
+      onClick: () => setClearOpen(true),
       className: "text-red-500",
       icon: <ScrollIcon className="h-4 w-4" />,
     },
@@ -129,6 +138,30 @@ export function CurrentUserNote({
 
   return (
     <div id={`umamin-${data.id}`}>
+      <AlertDialog open={clearOpen} onOpenChange={setClearOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear your note?</AlertDialogTitle>
+            <AlertDialogDescription>
+              It disappears from the notes feed for everyone. This can't be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button
+                disabled={clearNoteMutation.isPending}
+                variant="destructive"
+                onClick={() => clearNoteMutation.mutate()}
+              >
+                Clear note
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       <Card
         className={cn(
           "flex flex-col items-start gap-3 py-4",
@@ -147,9 +180,10 @@ export function CurrentUserNote({
 
           <div className="flex gap-x-1 items-center">
             {data.updatedAt && (
-              <span className="text-xs text-muted-foreground mr-1">
-                {shortTimeAgo(data.updatedAt)}
-              </span>
+              <TimeAgo
+                date={data.updatedAt}
+                className="text-xs text-muted-foreground mr-1"
+              />
             )}
             {currentUser.quietMode && <MessageSquareXIcon className="size-5" />}
             <Menu menuItems={menuItems} />

--- a/apps/web/src/routes/_social/-components/current-user-note.tsx
+++ b/apps/web/src/routes/_social/-components/current-user-note.tsx
@@ -28,6 +28,7 @@ import { GroupBadge } from "@/components/group-badge";
 import { Menu } from "@/components/menu";
 import { MusicEmbed } from "@/components/music-embed";
 import { PostBody } from "@/components/post-body";
+import { Link } from "@/lib/navigation";
 import { pageQueryOptions, queryKeys } from "@/lib/query";
 import { patchNote } from "@/lib/query-cache";
 import { fetchCurrentNote } from "@/lib/query-fetchers";
@@ -176,37 +177,49 @@ export function CurrentUserNote({
               </>
             ) : (
               <>
-                <Avatar
-                  className={cn("relative top-1", {
-                    "avatar-shine": hasUmaminPlus(currentUser?.createdAt),
-                  })}
+                <Link
+                  href={`/user/${currentUser.username}`}
+                  aria-label={`@${currentUser.username}'s profile`}
+                  className="shrink-0"
                 >
-                  <AvatarImage
-                    className="rounded-full"
-                    src={currentUser?.imageUrl ?? ""}
-                    alt="User avatar"
-                  />
-                  <AvatarFallback className="text-xs">
-                    <ScanFaceIcon />
-                  </AvatarFallback>
-                </Avatar>
+                  <Avatar
+                    className={cn("relative top-1", {
+                      "avatar-shine": hasUmaminPlus(currentUser?.createdAt),
+                    })}
+                  >
+                    <AvatarImage
+                      className="rounded-full"
+                      src={currentUser?.imageUrl ?? ""}
+                      alt="User avatar"
+                    />
+                    <AvatarFallback className="text-xs">
+                      <ScanFaceIcon />
+                    </AvatarFallback>
+                  </Avatar>
+                </Link>
 
                 <div className="flex flex-col mt-1">
                   <div className="flex items-center space-x-1">
-                    <span className="font-semibold flex-none text-base leading-none">
+                    <Link
+                      href={`/user/${currentUser.username}`}
+                      className="font-semibold flex-none text-base leading-none hover:underline"
+                    >
                       {currentUser.displayName
                         ? currentUser.displayName
                         : currentUser.username}
-                    </span>
+                    </Link>
                     {import.meta.env.VITE_VERIFIED_USERS?.split(",").includes(
                       currentUser.username,
                     ) && <BadgeCheckIcon className="w-4 h-4 text-pink-500" />}
                     <GroupBadge badge={currentUser.groupBadge} />
                   </div>
 
-                  <span className="text-muted-foreground truncate">
+                  <Link
+                    href={`/user/${currentUser.username}`}
+                    className="text-muted-foreground truncate hover:underline"
+                  >
                     @{currentUser.username}
-                  </span>
+                  </Link>
                 </div>
               </>
             )}

--- a/apps/web/src/routes/_social/-components/current-user-note.tsx
+++ b/apps/web/src/routes/_social/-components/current-user-note.tsx
@@ -15,7 +15,7 @@ import {
   AvatarImage,
 } from "@umamin/ui/components/avatar";
 import { Badge } from "@umamin/ui/components/badge";
-import { Button } from "@umamin/ui/components/button";
+import { buttonVariants } from "@umamin/ui/components/button";
 import {
   Card,
   CardContent,
@@ -149,14 +149,11 @@ export function CurrentUserNote({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction asChild>
-              <Button
-                disabled={clearNoteMutation.isPending}
-                variant="destructive"
-                onClick={() => clearNoteMutation.mutate()}
-              >
-                Clear note
-              </Button>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={() => clearNoteMutation.mutate()}
+            >
+              Clear note
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -178,7 +175,7 @@ export function CurrentUserNote({
             Your {data.isAnonymous ? "anonymous" : "shared"} note
           </Badge>
 
-          <div className="flex gap-x-1 items-center">
+          <div className="flex gap-x-2 items-center">
             {data.updatedAt && (
               <TimeAgo
                 date={data.updatedAt}

--- a/apps/web/src/routes/_social/-components/note-card.tsx
+++ b/apps/web/src/routes/_social/-components/note-card.tsx
@@ -40,6 +40,7 @@ import { GroupBadge } from "@/components/group-badge";
 import { Menu } from "@/components/menu";
 import { MusicEmbed } from "@/components/music-embed";
 import { PostBody } from "@/components/post-body";
+import { TimeAgo } from "@/components/time-ago";
 import {
   BURST_ACTION_REJECT_MESSAGE,
   useBurstAction,
@@ -55,7 +56,6 @@ import {
   isAlreadyReacted,
   isAlreadyRemoved,
   saveImage,
-  shortTimeAgo,
 } from "@/lib/utils";
 import {
   addNoteReactionAction,
@@ -333,9 +333,10 @@ export function NoteCard({
 
               <div className="flex gap-x-1 text-muted-foreground items-center">
                 {data.updatedAt && (
-                  <span className="text-xs text-muted-foreground mr-1">
-                    {shortTimeAgo(data.updatedAt)}
-                  </span>
+                  <TimeAgo
+                    date={data.updatedAt}
+                    className="text-xs text-muted-foreground mr-1"
+                  />
                 )}
 
                 {user?.quietMode && <MessageSquareXIcon className="size-5" />}
@@ -348,7 +349,7 @@ export function NoteCard({
                     aria-label="Reply"
                     aria-expanded={replyOpen}
                     onClick={() => setReplyOpen((prev) => !prev)}
-                    className="size-auto p-0 hover:bg-transparent text-muted-foreground"
+                    className="size-8 -m-1 hover:bg-transparent text-muted-foreground"
                   >
                     <MessageSquareTextIcon className="size-5" />
                   </Button>

--- a/apps/web/src/routes/_social/-components/note-card.tsx
+++ b/apps/web/src/routes/_social/-components/note-card.tsx
@@ -15,7 +15,7 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "@umamin/ui/components/avatar";
-import { Button } from "@umamin/ui/components/button";
+import { Button, buttonVariants } from "@umamin/ui/components/button";
 import {
   Card,
   CardContent,
@@ -237,14 +237,11 @@ export function NoteCard({
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction asChild>
-                  <Button
-                    disabled={removeMutation.isPending}
-                    variant="destructive"
-                    onClick={() => removeMutation.mutate()}
-                  >
-                    Continue
-                  </Button>
+                <AlertDialogAction
+                  className={buttonVariants({ variant: "destructive" })}
+                  onClick={() => removeMutation.mutate()}
+                >
+                  Continue
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
@@ -331,7 +328,9 @@ export function NoteCard({
                 </div>
               </div>
 
-              <div className="flex gap-x-1 text-muted-foreground items-center">
+              {/* gap-x-2: the reply and menu buttons each overhang 4px (-m-1),
+                  so a 4px gap would overlap their tap areas. */}
+              <div className="flex gap-x-2 text-muted-foreground items-center">
                 {data.updatedAt && (
                   <TimeAgo
                     date={data.updatedAt}

--- a/apps/web/src/routes/_social/-components/note-card.tsx
+++ b/apps/web/src/routes/_social/-components/note-card.tsx
@@ -321,9 +321,12 @@ export function NoteCard({
                   )}
 
                   {!data.isAnonymous && (
-                    <span className="text-muted-foreground truncate">
+                    <Link
+                      href={`/user/${username}`}
+                      className="text-muted-foreground truncate hover:underline"
+                    >
                       @{username}
-                    </span>
+                    </Link>
                   )}
                 </div>
               </div>

--- a/apps/web/src/routes/_social/-components/note-form.tsx
+++ b/apps/web/src/routes/_social/-components/note-form.tsx
@@ -27,6 +27,11 @@ const PROMPTS = [
   "what's living in your head rent-free?",
 ];
 
+// Mirrors the server's 500-char cap (api/actions/note.ts); counter appears
+// near the limit like thread-view's composer.
+const MAX_LENGTH = 500;
+const COUNTER_VISIBLE_AT = 400;
+
 export function NoteForm({ currentUser }: { currentUser: PublicUser }) {
   const queryClient = useQueryClient();
   const [content, setContent] = useState("");
@@ -155,8 +160,14 @@ export function NoteForm({ currentUser }: { currentUser: PublicUser }) {
         onChange={(e) => setContent(e.target.value)}
         id="message"
         placeholder={placeholder}
+        maxLength={MAX_LENGTH}
         className="font-display md:text-base"
       />
+      {content.length >= COUNTER_VISIBLE_AT && (
+        <p className="mt-1.5 text-right text-muted-foreground text-xs tabular-nums">
+          {MAX_LENGTH - content.length} left
+        </p>
+      )}
 
       {parsedMusic && (
         <div className="mt-2 flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">

--- a/apps/web/src/routes/_social/-components/post-card-main.tsx
+++ b/apps/web/src/routes/_social/-components/post-card-main.tsx
@@ -229,16 +229,22 @@ export function PostCardMain({ data, imageId, isAuthenticated }: Props) {
       className="px-7 container border-x-0 sm:border-x border border-muted py-6 bg-muted/50 sm:rounded-md sm:px-6"
     >
       <div className="flex justify-center gap-3">
-        <Avatar
-          className={cn({
-            "avatar-shine": hasUmaminPlus(author.createdAt),
-          })}
+        <Link
+          href={`/user/${author.username}`}
+          aria-label={`@${author.username}'s profile`}
+          className="shrink-0 self-start"
         >
-          <AvatarImage src={author.imageUrl ?? ""} alt="User avatar" />
-          <AvatarFallback>
-            <ScanFaceIcon />
-          </AvatarFallback>
-        </Avatar>
+          <Avatar
+            className={cn({
+              "avatar-shine": hasUmaminPlus(author.createdAt),
+            })}
+          >
+            <AvatarImage src={author.imageUrl ?? ""} alt="User avatar" />
+            <AvatarFallback>
+              <ScanFaceIcon />
+            </AvatarFallback>
+          </Avatar>
+        </Link>
 
         <div className="flex justify-between w-full items-center text-[15px]">
           <div className="flex items-center space-x-1">
@@ -254,7 +260,12 @@ export function PostCardMain({ data, imageId, isAuthenticated }: Props) {
                 author.username,
               ) && <BadgeCheckIcon className="w-4 h-4 text-pink-500" />}
             <GroupBadge badge={author.groupBadge} />
-            <span className="text-muted-foreground">@{author.username}</span>
+            <Link
+              href={`/user/${author.username}`}
+              className="truncate text-muted-foreground hover:underline"
+            >
+              @{author.username}
+            </Link>
           </div>
 
           <div className="flex items-center gap-2 text-muted-foreground">

--- a/apps/web/src/routes/_social/-components/post-card-main.tsx
+++ b/apps/web/src/routes/_social/-components/post-card-main.tsx
@@ -294,7 +294,9 @@ export function PostCardMain({ data, imageId, isAuthenticated }: Props) {
 
         {data.quotedPostId && <QuotedPostCard post={data.quotedPost ?? null} />}
 
-        <div className="flex items-center space-x-4 text-muted-foreground mt-4">
+        {/* gap-4 (not space-x) so the controls' negative margins can enlarge
+            their tap targets without shifting the visual layout. */}
+        <div className="flex items-center gap-4 text-muted-foreground mt-4">
           <Button
             disabled={!isAuthenticated}
             type="button"
@@ -303,7 +305,7 @@ export function PostCardMain({ data, imageId, isAuthenticated }: Props) {
             aria-label={liked ? "Unlike post" : "Like post"}
             aria-pressed={liked}
             className={cn(
-              "h-auto gap-0 p-0 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
+              "h-auto gap-0 -m-2 p-2 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
               liked
                 ? "text-pink-500 hover:text-pink-500"
                 : "hover:text-muted-foreground",
@@ -325,7 +327,7 @@ export function PostCardMain({ data, imageId, isAuthenticated }: Props) {
                 variant="ghost"
                 aria-label="Repost options"
                 className={cn(
-                  "h-auto gap-0 p-0 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
+                  "h-auto gap-0 -m-2 p-2 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
                   reposted
                     ? "text-emerald-600 hover:text-emerald-600"
                     : "hover:text-muted-foreground",

--- a/apps/web/src/routes/_social/-components/post-card.tsx
+++ b/apps/web/src/routes/_social/-components/post-card.tsx
@@ -306,16 +306,22 @@ export function PostCard({
         />
       )}
 
-      <Avatar
-        className={cn({
-          "avatar-shine": hasUmaminPlus(author?.createdAt),
-        })}
+      <Link
+        href={`/user/${author?.username}`}
+        aria-label={`@${author?.username}'s profile`}
+        className="relative z-10 shrink-0 self-start"
       >
-        <AvatarImage src={author?.imageUrl ?? ""} alt="User avatar" />
-        <AvatarFallback>
-          <ScanFaceIcon />
-        </AvatarFallback>
-      </Avatar>
+        <Avatar
+          className={cn({
+            "avatar-shine": hasUmaminPlus(author?.createdAt),
+          })}
+        >
+          <AvatarImage src={author?.imageUrl ?? ""} alt="User avatar" />
+          <AvatarFallback>
+            <ScanFaceIcon />
+          </AvatarFallback>
+        </Avatar>
+      </Link>
 
       <div className="w-full min-w-0">
         <div className="flex justify-between">
@@ -332,7 +338,12 @@ export function PostCard({
                 author.username,
               ) && <BadgeCheckIcon className="w-4 h-4 text-pink-500" />}
             <GroupBadge badge={author?.groupBadge} />
-            <span className="text-muted-foreground">@{author?.username}</span>
+            <Link
+              href={`/user/${author?.username}`}
+              className="relative z-10 truncate text-muted-foreground hover:underline"
+            >
+              @{author?.username}
+            </Link>
           </div>
 
           <div className="relative z-10 flex items-center gap-2 text-muted-foreground">
@@ -457,15 +468,14 @@ export function PostCard({
           )}
 
           {!isComment && (
-            <div className="flex space-x-1 items-center">
-              <Link
-                href={`/post/${data?.id}`}
-                aria-label={`View ${commentCount ?? 0} comments`}
-              >
-                <MessageCircleIcon className="h-5 w-5" />
-              </Link>
+            <Link
+              href={`/post/${data?.id}`}
+              aria-label={`View ${commentCount ?? 0} comments`}
+              className="flex space-x-1 items-center"
+            >
+              <MessageCircleIcon className="h-5 w-5" />
               <span>{commentCount ?? 0}</span>
-            </div>
+            </Link>
           )}
         </div>
       </div>

--- a/apps/web/src/routes/_social/-components/post-card.tsx
+++ b/apps/web/src/routes/_social/-components/post-card.tsx
@@ -396,7 +396,9 @@ export function PostCard({
           <QuotedPostCard post={quotablePost.quotedPost ?? null} />
         )}
 
-        <div className="relative z-10 flex items-center space-x-4 text-muted-foreground mt-4">
+        {/* gap-4 (not space-x) so the controls' negative margins can enlarge
+            their tap targets without shifting the visual layout. */}
+        <div className="relative z-10 flex items-center gap-4 text-muted-foreground mt-4">
           <Button
             type="button"
             variant="ghost"
@@ -405,7 +407,7 @@ export function PostCard({
             aria-label={`${liked ? "Unlike" : "Like"} ${isComment ? "comment" : "post"}`}
             aria-pressed={liked}
             className={cn(
-              "h-auto gap-0 p-0 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
+              "h-auto gap-0 -m-2 p-2 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
               liked
                 ? "text-pink-500 hover:text-pink-500"
                 : "hover:text-muted-foreground",
@@ -428,7 +430,7 @@ export function PostCard({
                   disabled={!isAuthenticated}
                   aria-label="Repost options"
                   className={cn(
-                    "h-auto gap-0 p-0 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
+                    "h-auto gap-0 -m-2 p-2 flex space-x-1 items-center hover:bg-transparent disabled:opacity-100",
                     reposted
                       ? "text-emerald-600 hover:text-emerald-600"
                       : "hover:text-muted-foreground",
@@ -471,7 +473,7 @@ export function PostCard({
             <Link
               href={`/post/${data?.id}`}
               aria-label={`View ${commentCount ?? 0} comments`}
-              className="flex space-x-1 items-center"
+              className="flex space-x-1 items-center -m-2 p-2"
             >
               <MessageCircleIcon className="h-5 w-5" />
               <span>{commentCount ?? 0}</span>

--- a/apps/web/src/routes/_social/-components/repost-header.tsx
+++ b/apps/web/src/routes/_social/-components/repost-header.tsx
@@ -1,7 +1,7 @@
 import { BadgeCheckIcon, Repeat2Icon } from "lucide-react";
+import { TimeAgo } from "@/components/time-ago";
 import { Link } from "@/lib/navigation";
 import type { FeedAuthor } from "@/lib/types";
-import { shortTimeAgo } from "@/lib/utils";
 
 // Plain-repost attribution line — quotes are real posts with their own card.
 export function RepostHeader({
@@ -26,7 +26,9 @@ export function RepostHeader({
         @{user.username}
       </Link>
       {verified && <BadgeCheckIcon className="w-4 h-4 text-pink-500 mr-1" />}
-      <span>reposted {shortTimeAgo(createdAt)}</span>
+      <span>
+        reposted <TimeAgo date={createdAt} />
+      </span>
     </div>
   );
 }

--- a/apps/web/src/routes/_social/to.$username.tsx
+++ b/apps/web/src/routes/_social/to.$username.tsx
@@ -4,6 +4,7 @@ import { BadgeCheckIcon, LockIcon } from "lucide-react";
 import { ClientOnlyAdContainer } from "@/components/ad-container-client";
 import { RouteSegmentError } from "@/components/route-segment-error";
 import { ShareButton } from "@/components/share-button";
+import { Link } from "@/lib/navigation";
 import { pageSeo } from "@/lib/seo";
 import type { PublicUser } from "@/lib/types";
 import { formatUsername } from "@/lib/utils";
@@ -55,9 +56,12 @@ function SendMessage() {
         <div className="bg-background border-b w-full item-center px-6 py-4 rounded-t-2xl flex justify-between flex-row">
           <div className="flex items-center space-x-1">
             <span className="text-muted-foreground">To:</span>
-            <p className="font-semibold text-sm">
+            <Link
+              href={`/user/${user.username}`}
+              className="font-semibold text-sm hover:underline"
+            >
               {user?.displayName ? user?.displayName : user?.username}
-            </p>
+            </Link>
             {import.meta.env.VITE_VERIFIED_USERS?.split(",").includes(
               user.username,
             ) && <BadgeCheckIcon className="w-4 h-4 text-pink-500" />}

--- a/apps/web/src/server-lib/data.ts
+++ b/apps/web/src/server-lib/data.ts
@@ -2759,27 +2759,41 @@ export async function getNotificationsPage(
 
   const baseCondition = eq(notificationTable.recipientId, params.viewerId);
 
-  const rows = await db
-    .select({
-      id: notificationTable.id,
-      type: notificationTable.type,
-      targetId: notificationTable.targetId,
-      count: notificationTable.count,
-      preview: notificationTable.preview,
-      updatedAt: notificationTable.updatedAt,
-      actor: {
-        username: userTable.username,
-        displayName: userTable.displayName,
-        imageUrl: userTable.imageUrl,
-      },
-    })
-    .from(notificationTable)
-    .leftJoin(userTable, eq(notificationTable.actorId, userTable.id))
-    .where(
-      cursorCondition ? and(baseCondition, cursorCondition) : baseCondition,
-    )
-    .orderBy(desc(notificationTable.updatedAt), desc(notificationTable.id))
-    .limit(NOTIFICATIONS_PAGE_SIZE + 1);
+  // The seen watermark rides the first page (async-parallel, no waterfall) so
+  // the client can mark which rows are new. Read from the user row directly —
+  // getSession's copy can lag mark-seen (session cache).
+  const [rows, viewerRows] = await Promise.all([
+    db
+      .select({
+        id: notificationTable.id,
+        type: notificationTable.type,
+        targetId: notificationTable.targetId,
+        count: notificationTable.count,
+        preview: notificationTable.preview,
+        updatedAt: notificationTable.updatedAt,
+        actor: {
+          username: userTable.username,
+          displayName: userTable.displayName,
+          imageUrl: userTable.imageUrl,
+        },
+      })
+      .from(notificationTable)
+      .leftJoin(userTable, eq(notificationTable.actorId, userTable.id))
+      .where(
+        cursorCondition ? and(baseCondition, cursorCondition) : baseCondition,
+      )
+      .orderBy(desc(notificationTable.updatedAt), desc(notificationTable.id))
+      .limit(NOTIFICATIONS_PAGE_SIZE + 1),
+    parsedCursor
+      ? Promise.resolve([])
+      : db
+          .select({
+            lastSeenNotificationsAt: userTable.lastSeenNotificationsAt,
+          })
+          .from(userTable)
+          .where(eq(userTable.id, params.viewerId))
+          .limit(1),
+  ]);
 
   const { hasMore, pageRows } = getPageRows(rows, NOTIFICATIONS_PAGE_SIZE);
   const lastRow = pageRows[pageRows.length - 1];
@@ -2790,6 +2804,11 @@ export async function getNotificationsPage(
       hasMore && lastRow
         ? `${lastRow.updatedAt.getTime()}.${lastRow.id}`
         : null,
+    ...(parsedCursor
+      ? {}
+      : {
+          lastSeen: viewerRows[0]?.lastSeenNotificationsAt?.getTime() ?? 0,
+        }),
   };
 }
 


### PR DESCRIPTION
QoL release. Highlights:

- Avatars and @usernames open profiles on every surface (feed, comments, notes, group members, group chat, reactions, follow lists); in the feed the avatar previously fell through to the post overlay.
- Draft protection: closing the composer with unsent text, images, or a poll asks before discarding.
- Confirmations for kicking a group member, deleting a group chat message, and clearing your note; destructive confirm buttons render red.
- Group chat: "new messages" jump pill, growing composer, 1000-char counter.
- Unread notifications get a dot (seen watermark now rides the first page of the notifications read).
- Bigger tap targets on like/repost/comment/card menus with zero density change; char counters in the notes composer and settings; timestamps show exact date/time on hover everywhere; settings tabs are linkable; re-tapping the active bottom-nav tab scrolls to top.

Full details in the 7.4.0 changelog entry. Validated: check-types, both vitest runners (233 + 117), Biome, production build.