### PR TITLE
fix(db): construct libSQL clients lazily so builds don't need credentials

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,18 +1,40 @@
 import { drizzle } from "drizzle-orm/libsql";
 import * as schema from "./schema";
 
-export const db = drizzle({
-  connection: {
-    url: process.env.TURSO_CONNECTION_URL ?? "",
-    authToken: process.env.TURSO_AUTH_TOKEN ?? "",
+function connect() {
+  return drizzle({
+    connection: {
+      url: process.env.TURSO_CONNECTION_URL ?? "",
+      authToken: process.env.TURSO_AUTH_TOKEN ?? "",
+    },
+    // cache:
+    //   process.env.NODE_ENV === "production"
+    //     ? upstashCache({
+    //         url: process.env.UPSTASH_REDIS_REST_URL ?? "",
+    //         token: process.env.UPSTASH_REDIS_REST_TOKEN ?? "",
+    //         global: true,
+    //       })
+    //     : undefined,
+    schema,
+  });
+}
+
+type Database = ReturnType<typeof connect>;
+
+let client: Database | undefined;
+
+// Constructed on first property access, not at import. libSQL validates the URL
+// eagerly, so a module-scope client turns "TURSO_CONNECTION_URL is unset" into a
+// crash at IMPORT time — and Next evaluates route modules while collecting page
+// data, which made `next build` fail with URL_INVALID wherever the env is absent
+// (a fork PR's CI run, where GitHub withholds repository secrets). Deferring it
+// means only code that actually queries needs the credentials.
+export const db: Database = new Proxy({} as Database, {
+  get(_target, prop) {
+    client ??= connect();
+    const value = Reflect.get(client, prop);
+    // Bind to the real client: with the proxy as `this`, drizzle's internal
+    // private-field access throws.
+    return typeof value === "function" ? value.bind(client) : value;
   },
-  // cache:
-  //   process.env.NODE_ENV === "production"
-  //     ? upstashCache({
-  //         url: process.env.UPSTASH_REDIS_REST_URL ?? "",
-  //         token: process.env.UPSTASH_REDIS_REST_TOKEN ?? "",
-  //         global: true,
-  //       })
-  //     : undefined,
-  schema,
 });

--- a/packages/db/src/web.ts
+++ b/packages/db/src/web.ts
@@ -1,11 +1,26 @@
 import { drizzle } from "drizzle-orm/libsql/web";
 import * as schema from "./schema";
 
-// HTTP-only libSQL driver for edge/Workers runtimes; same env-var contract as `.`.
-export const db = drizzle({
-  connection: {
-    url: process.env.TURSO_CONNECTION_URL ?? "",
-    authToken: process.env.TURSO_AUTH_TOKEN ?? "",
+// HTTP-only libSQL driver for edge/Workers runtimes; same env-var contract as `.`,
+// and lazy for the same reason — see the note in ./index.ts.
+function connect() {
+  return drizzle({
+    connection: {
+      url: process.env.TURSO_CONNECTION_URL ?? "",
+      authToken: process.env.TURSO_AUTH_TOKEN ?? "",
+    },
+    schema,
+  });
+}
+
+type Database = ReturnType<typeof connect>;
+
+let client: Database | undefined;
+
+export const db: Database = new Proxy({} as Database, {
+  get(_target, prop) {
+    client ??= connect();
+    const value = Reflect.get(client, prop);
+    return typeof value === "function" ? value.bind(client) : value;
   },
-  schema,
 });

--- a/packages/org-db/src/index.ts
+++ b/packages/org-db/src/index.ts
@@ -1,10 +1,32 @@
 import { drizzle } from "drizzle-orm/libsql";
 import * as schema from "./schema";
 
-export const db = drizzle({
-  connection: {
-    url: process.env.TURSO_CONNECTION_URL ?? "",
-    authToken: process.env.TURSO_AUTH_TOKEN ?? "",
+function connect() {
+  return drizzle({
+    connection: {
+      url: process.env.TURSO_CONNECTION_URL ?? "",
+      authToken: process.env.TURSO_AUTH_TOKEN ?? "",
+    },
+    schema,
+  });
+}
+
+type Database = ReturnType<typeof connect>;
+
+let client: Database | undefined;
+
+// Constructed on first property access, not at import. libSQL validates the URL
+// eagerly, so a module-scope client turns "TURSO_CONNECTION_URL is unset" into a
+// crash at IMPORT time — and Next evaluates route modules while collecting page
+// data, which made `next build` fail with URL_INVALID wherever the env is absent
+// (a fork PR's CI run, where GitHub withholds repository secrets). Deferring it
+// means only code that actually queries needs the credentials.
+export const db: Database = new Proxy({} as Database, {
+  get(_target, prop) {
+    client ??= connect();
+    const value = Reflect.get(client, prop);
+    // Bind to the real client: with the proxy as `this`, drizzle's internal
+    // private-field access throws.
+    return typeof value === "function" ? value.bind(client) : value;
   },
-  schema,
 });


### PR DESCRIPTION
## Why

`build` failed on #338 — a fork PR — with the `apps/org` Next build dying at page-data collection:

```
Error [LibsqlError]: URL_INVALID: The URL '' is not in a valid format
Failed to collect page data for /api/cron/cleanup-sessions
```

Nothing to do with that PR's changes. `packages/db` and `packages/org-db` both construct their libSQL client at **module scope** from `process.env.TURSO_CONNECTION_URL ?? ""`, and libSQL validates the URL eagerly. So importing the module throws whenever the env is absent — and Next evaluates route modules while collecting page data, which turns a missing credential into a failed *build*.

CI's `build` job feeds that var from `secrets.TURSO_CONNECTION_URL`, and **GitHub withholds repository secrets from `pull_request` runs on forks**. So every external contributor's PR fails `build`, regardless of what they changed.

It has been masked until now: fork PRs also get no `TURBO_TOKEN`, so there is no remote cache (`Cached: 0 cached, 7 total` on that run). On a same-repo PR `org#build` is a cache hit and never executes.

## What

Defer client construction to first property access via a `Proxy`, in all three entry points that had the pattern — `packages/db/src/index.ts`, `packages/db/src/web.ts`, `packages/org-db/src/index.ts`. Only code that actually queries needs credentials now. No call-site changes: all 26 `import { db }` consumers are untouched.

Functions are bound to the real client rather than returned bare, because with the proxy as `this` drizzle's internal private-field access throws.

## Verification

The failure reproduces on `dev` and is gone after the change:

```
# before — apps/org, empty env
Error [LibsqlError]: URL_INVALID  →  Failed to collect page data

# after — whole monorepo, empty env
TURSO_CONNECTION_URL="" TURSO_AUTH_TOKEN="" pnpm turbo run build --force
Tasks:    7 successful, 7 total
```

A proxy around drizzle is the kind of thing that type-checks and then breaks at runtime, so I exercised a real libSQL client through it:

| Path | Result |
| --- | --- |
| `db.run` / `db.all` | `[{"v":"a"},{"v":"b"}]` |
| `db.transaction()` | committed, `{"n":3}` |
| `db.query` (relational property) | object |
| `db.$client`, `db.select` | present |

Full gate green: `build` 7/7, `check-types` 8/8, `pnpm test` 704 tests, `test:workers` 120, Biome 1056 files. Also ran the archived suite, since `apps/www` is the heaviest consumer of the root export: `pnpm --filter=www test:archived` → **453 passed**.

No CHANGELOG entry — internal mechanics, nothing a user notices.
