### PR TITLE
RC: v7.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,10 @@ any that are empty.
 - **Deprecated** — features marked for removal.
 - **Removed** — features removed.
 
-## [7.6.0] - 2026-08-21
+## [7.6.1] - 2026-08-21
 
 ### Changed
 
-- Everyone has a default profile picture now: a small coloured character that belongs to your account and appears anywhere you haven't uploaded a photo — your profile, the feed, notes, comments, notifications, follower lists, group members and group chat. It replaces the generic outline and the two-letter initials, it's the same one every time, and it stays yours even if you change your username. Saved post and note images pick it up too.
-- Anonymous notes still show the plain outline, so a default picture can never tie one back to an account.
 - Signing up with Google no longer takes your Google profile photo. New accounts start on their default picture, and linking Google to an existing account never changes the photo you already have.
 - Removing your profile photo now lives next to the upload button, under Profile Photo in General settings, and puts your default picture back.
 
@@ -31,6 +29,13 @@ any that are empty.
 
 - "Use Google Photo" is gone from Settings. Upload a photo, or keep the default picture — accounts that already show a Google photo can clear it with Remove photo.
 - The "Display Picture" switch is gone from Privacy settings; it only ever deleted an uploaded photo, which Remove photo now does where the photo actually is.
+
+## [7.6.0] - 2026-08-21
+
+### Changed
+
+- Everyone has a default profile picture now: a small coloured character that belongs to your account and appears anywhere you haven't uploaded a photo — your profile, the feed, notes, comments, notifications, follower lists, group members and group chat. It replaces the generic outline and the two-letter initials, it's the same one every time, and it stays yours even if you change your username. Saved post and note images pick it up too.
+- Anonymous notes still show the plain outline, so a default picture can never tie one back to an account.
 
 ## [7.5.0] - 2026-08-07
 
@@ -937,6 +942,7 @@ Turso query cost, and a set of audit-driven correctness and security fixes.
 - Stopped logging raw errors that could contain usernames or token internals.
 - Added a daily cron that prunes expired sessions.
 
+[7.6.1]: https://github.com/omsimos/umamin/compare/v7.6.0...v7.6.1
 [7.6.0]: https://github.com/omsimos/umamin/compare/v7.5.0...v7.6.0
 [7.5.0]: https://github.com/omsimos/umamin/compare/v7.4.0...v7.5.0
 [7.4.0]: https://github.com/omsimos/umamin/compare/v7.3.0...v7.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ any that are empty.
 
 - Everyone has a default profile picture now: a small coloured character that belongs to your account and appears anywhere you haven't uploaded a photo — your profile, the feed, notes, comments, notifications, follower lists, group members and group chat. It replaces the generic outline and the two-letter initials, it's the same one every time, and it stays yours even if you change your username. Saved post and note images pick it up too.
 - Anonymous notes still show the plain outline, so a default picture can never tie one back to an account.
+- Signing up with Google no longer takes your Google profile photo. New accounts start on their default picture, and linking Google to an existing account never changes the photo you already have.
+- Removing your profile photo now lives next to the upload button, under Profile Photo in General settings, and puts your default picture back.
+
+### Removed
+
+- "Use Google Photo" is gone from Settings. Upload a photo, or keep the default picture — accounts that already show a Google photo can clear it with Remove photo.
+- The "Display Picture" switch is gone from Privacy settings; it only ever deleted an uploaded photo, which Remove photo now does where the photo actually is.
 
 ## [7.5.0] - 2026-08-07
 

--- a/apps/web/src/api/actions/index.ts
+++ b/apps/web/src/api/actions/index.ts
@@ -81,11 +81,10 @@ import {
   getCurrentUserHandler,
   getUserProfileHandler,
   removeProfileBannerHandler,
-  toggleDisplayPictureHandler,
+  removeProfilePhotoHandler,
   toggleQuietModeHandler,
   unblockUserHandler,
   unfollowUserHandler,
-  updateAvatarHandler,
   updateBlockedWordsHandler,
   updatePasswordHandler,
   updateProfileBannerHandler,
@@ -156,13 +155,12 @@ export const actionsApp = new Hono<AppBindings>()
   .post("/actions/unfollowUserAction", unfollowUserHandler)
   .post("/actions/blockUserAction", blockUserHandler)
   .post("/actions/unblockUserAction", unblockUserHandler)
-  .post("/actions/toggleDisplayPictureAction", toggleDisplayPictureHandler)
   .post("/actions/toggleQuietModeAction", toggleQuietModeHandler)
   .post("/actions/updateBlockedWordsAction", updateBlockedWordsHandler)
-  .post("/actions/updateAvatarAction", updateAvatarHandler)
   .post("/actions/updateProfilePhotoAction", updateProfilePhotoHandler)
   .post("/actions/updateProfileBannerAction", updateProfileBannerHandler)
   .post("/actions/removeProfileBannerAction", removeProfileBannerHandler)
+  .post("/actions/removeProfilePhotoAction", removeProfilePhotoHandler)
   // group
   .post("/actions/createGroupAction", createGroupHandler)
   .post("/actions/inviteToGroupAction", inviteToGroupHandler)

--- a/apps/web/src/api/actions/user.ts
+++ b/apps/web/src/api/actions/user.ts
@@ -28,19 +28,6 @@ import {
 import { setSessionCookie } from "../../server-lib/session-cookie";
 import { ctxDb, defer } from "./_shared";
 
-// Only Google profile pictures may be applied by URL — everything else is a raw
-// <img src> tracking/deanonymization vector. Uploaded photos take the R2 path.
-const ALLOWED_AVATAR_HOSTS = new Set(["lh3.googleusercontent.com"]);
-
-function isAllowedAvatarUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "https:" && ALLOWED_AVATAR_HOSTS.has(url.hostname);
-  } catch {
-    return false;
-  }
-}
-
 // Set the photo and return the value it replaced, read in the same transaction
 // so R2 cleanup targets the object that actually became unreachable.
 async function swapUserImageUrl(
@@ -527,36 +514,6 @@ export const unblockUserHandler = action(
   },
 );
 
-export const toggleDisplayPictureHandler = action(
-  {
-    schema: z.string().optional(),
-    auth: "user",
-    rateLimit: {
-      name: "write",
-      key: ({ user }) => `displaypic:${user.id}`,
-    },
-  },
-  async (accountImgUrl, { user, c }) => {
-    const db = ctxDb(c);
-    if (
-      !user.imageUrl &&
-      (!accountImgUrl || !isAllowedAvatarUrl(accountImgUrl))
-    ) {
-      return { error: "Invalid input" };
-    }
-
-    const imageUrl = user.imageUrl ? null : (accountImgUrl ?? null);
-    const previousImageUrl = await swapUserImageUrl(db, user.id, imageUrl);
-
-    if (!imageUrl) {
-      const r2 = createR2(c.env);
-      if (r2) await r2.deleteR2Avatar(previousImageUrl);
-    }
-
-    return { imageUrl };
-  },
-);
-
 export const toggleQuietModeHandler = action(
   {
     auth: "user",
@@ -599,26 +556,21 @@ export const updateBlockedWordsHandler = action(
   },
 );
 
-export const updateAvatarHandler = action(
+export const removeProfilePhotoHandler = action(
   {
-    schema: z.string(),
     auth: "user",
-    rateLimit: { name: "write", key: ({ user }) => `avatar:${user.id}` },
+    rateLimit: { name: "write", key: ({ user }) => `avatarrm:${user.id}` },
   },
-  async (imageUrl, { user, c }) => {
+  async (_input, { user, c }) => {
     const db = ctxDb(c);
-    if (!isAllowedAvatarUrl(imageUrl)) {
-      return { error: "Invalid input" };
-    }
+    const previousImageUrl = await swapUserImageUrl(db, user.id, null);
 
-    const previousImageUrl = await swapUserImageUrl(db, user.id, imageUrl);
+    // No-ops on a Google URL left over from an older signup — only our own
+    // avatars/ objects are deletable.
+    const r2 = createR2(c.env);
+    if (r2) await r2.deleteR2Avatar(previousImageUrl);
 
-    if (previousImageUrl && previousImageUrl !== imageUrl) {
-      const r2 = createR2(c.env);
-      if (r2) await r2.deleteR2Avatar(previousImageUrl);
-    }
-
-    return { success: true, imageUrl };
+    return { success: true };
   },
 );
 

--- a/apps/web/src/api/auth/google.ts
+++ b/apps/web/src/api/auth/google.ts
@@ -181,12 +181,10 @@ export const googleAuthApp = new Hono<AppBindings>()
         return c.redirect("/settings?error=already_linked", 302);
       } else if (user) {
         await db.transaction(async (tx) => {
-          if (!user.imageUrl && googleUser.picture) {
-            await tx
-              .update(userTable)
-              .set({ imageUrl: googleUser.picture })
-              .where(eq(userTable.id, user.id));
-          }
+          // Linking never touches imageUrl: the default profile picture is the
+          // account's own blobatar, and adopting a Google photo would silently
+          // change how someone looks to everyone else. `picture` is stored for
+          // the linked-account card only.
           await tx.insert(accountTable).values({
             providerId: "google",
             providerUserId: googleUser.sub,
@@ -233,7 +231,6 @@ export const googleAuthApp = new Hono<AppBindings>()
       await db.transaction(async (tx) => {
         await tx.insert(userTable).values({
           id: userId,
-          imageUrl: googleUser.picture,
           username: `user_${usernameId}`,
         });
         await tx.insert(accountTable).values({

--- a/apps/web/src/routes/-settings/actions.ts
+++ b/apps/web/src/routes/-settings/actions.ts
@@ -29,16 +29,6 @@ export function updatePasswordAction(input: PasswordInput) {
   return callAction<{ success: true }>("updatePasswordAction", input);
 }
 
-export function toggleDisplayPictureAction(accountImgUrl?: string) {
-  // Optional-string schema: an empty body parses to undefined server-side, but
-  // callAction always sends a JSON body — so pass "" (a valid string) when the
-  // user has no Google picture (the toggle-off path ignores it).
-  return callAction<{ imageUrl: string | null }>(
-    "toggleDisplayPictureAction",
-    accountImgUrl ?? "",
-  );
-}
-
 export function toggleQuietModeAction() {
   return callAction<{ quietMode: boolean }>("toggleQuietModeAction");
 }
@@ -54,13 +44,6 @@ export function unblockUserAction(input: { userId: string }) {
   return callAction<{ success?: boolean }>("unblockUserAction", input);
 }
 
-export function updateAvatarAction(imageUrl: string) {
-  return callAction<{ success: true; imageUrl: string }>(
-    "updateAvatarAction",
-    imageUrl,
-  );
-}
-
 export function updateProfilePhotoAction(input: { key: string }) {
   return callAction<{ success: true; imageUrl: string }>(
     "updateProfilePhotoAction",
@@ -73,6 +56,10 @@ export function updateProfileBannerAction(input: { key: string }) {
     "updateProfileBannerAction",
     input,
   );
+}
+
+export function removeProfilePhotoAction() {
+  return callAction<{ success: true }>("removeProfilePhotoAction");
 }
 
 export function removeProfileBannerAction() {

--- a/apps/web/src/routes/-settings/privacy-settings.tsx
+++ b/apps/web/src/routes/-settings/privacy-settings.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Label } from "@umamin/ui/components/label";
 import { Switch } from "@umamin/ui/components/switch";
-import { CircleUserRoundIcon, MessageCircleOffIcon } from "lucide-react";
+import { MessageCircleOffIcon } from "lucide-react";
 import { toast } from "sonner";
 import { useSingleFlightAction } from "@/hooks/use-single-flight-action";
 import { queryKeys } from "@/lib/query";
@@ -11,7 +11,7 @@ import type {
   UserProfileResponse,
   UserWithAccount,
 } from "@/lib/types";
-import { toggleDisplayPictureAction, toggleQuietModeAction } from "./actions";
+import { toggleQuietModeAction } from "./actions";
 import { BlockedUsersSection } from "./blocked-users-section";
 import { BlockedWordsSection } from "./blocked-words-section";
 import { PushNotificationToggle } from "./push-notification-toggle";
@@ -30,45 +30,7 @@ export function PrivacySettings({ user }: { user: UserWithAccount }) {
     );
   };
 
-  const toggleDisplayPicture = useSingleFlightAction(
-    toggleDisplayPictureAction,
-  );
   const toggleQuietMode = useSingleFlightAction(toggleQuietModeAction);
-
-  const displayPictureMutation = useMutation({
-    mutationFn: async () => {
-      if (!user.imageUrl) {
-        throw new Error("Upload a photo or connect a Google account");
-      }
-
-      const res = await toggleDisplayPicture(user.account?.picture);
-      if ("error" in res && res.error) {
-        throw new Error(res.error);
-      }
-
-      return "imageUrl" in res && !!res.imageUrl;
-    },
-    onSuccess: (data) => {
-      const imageUrl = data ? (user.account?.picture ?? user.imageUrl) : null;
-
-      queryClient.setQueryData<CurrentUserResponse>(
-        queryKeys.currentUser(),
-        (current) =>
-          patchCurrentUser(current, (currentUser) => ({
-            ...currentUser,
-            imageUrl,
-          })),
-      );
-      patchOwnProfile({ imageUrl });
-      toast.success(
-        data ? "Profile photo displayed." : "Profile photo removed.",
-      );
-    },
-    onError: (err) => {
-      console.error(err);
-      toast.error(err.message ?? "Couldn't update photo.");
-    },
-  });
 
   const quietModeMutation = useMutation({
     mutationFn: async () => {
@@ -102,27 +64,6 @@ export function PrivacySettings({ user }: { user: UserWithAccount }) {
       <section>
         <Label>Update Preferences</Label>
         <div className="flex items-center space-x-4 rounded-md border p-4 mt-2">
-          <CircleUserRoundIcon className="size-6" />
-          <div className="flex-1 space-y-1">
-            <p className="text-sm font-medium leading-none">Display Picture</p>
-            {user.imageUrl ? (
-              <p className="text-sm text-muted-foreground">
-                Turning this off permanently deletes an uploaded photo
-              </p>
-            ) : (
-              <p className="text-sm text-yellow-600">
-                Upload a photo or connect a Google account
-              </p>
-            )}
-          </div>
-          <Switch
-            disabled={displayPictureMutation.isPending || !user.imageUrl}
-            checked={!!user?.imageUrl}
-            onCheckedChange={() => displayPictureMutation.mutate()}
-          />
-        </div>
-
-        <div className="flex items-center space-x-4 rounded-md border p-4 mt-4">
           <MessageCircleOffIcon className="size-6" />
           <div className="flex-1 space-y-1">
             <p className="text-sm font-medium leading-none">Quiet Mode</p>

--- a/apps/web/src/routes/-settings/profile-media.tsx
+++ b/apps/web/src/routes/-settings/profile-media.tsx
@@ -37,7 +37,7 @@ import {
   presignAvatarUploadAction,
   presignBannerUploadAction,
   removeProfileBannerAction,
-  updateAvatarAction,
+  removeProfilePhotoAction,
   updateProfileBannerAction,
   updateProfilePhotoAction,
 } from "./actions";
@@ -61,7 +61,6 @@ export function ProfileMedia({ user }: { user: UserWithAccount }) {
   const pickKind = useRef<CropTarget["kind"]>("avatar");
   const [cropTarget, setCropTarget] = useState<CropTarget | null>(null);
 
-  const googlePicture = user.account?.picture;
   const uploadsAvailable = postImagesEnabled(
     import.meta.env.VITE_R2_PUBLIC_URL,
   );
@@ -69,7 +68,7 @@ export function ProfileMedia({ user }: { user: UserWithAccount }) {
   const applyBanner = useSingleFlightAction(updateProfileBannerAction);
   const applyAvatar = useSingleFlightAction(updateProfilePhotoAction);
   const removeBanner = useSingleFlightAction(removeProfileBannerAction);
-  const applyGooglePhoto = useSingleFlightAction(updateAvatarAction);
+  const removePhoto = useSingleFlightAction(removeProfilePhotoAction);
 
   const patchImage = (updates: {
     imageUrl?: string | null;
@@ -192,22 +191,20 @@ export function ProfileMedia({ user }: { user: UserWithAccount }) {
     },
   });
 
-  const googlePhotoMutation = useMutation({
+  const removePhotoMutation = useMutation({
     mutationFn: async () => {
-      if (!googlePicture) return undefined;
-      const res = await applyGooglePhoto(googlePicture);
+      const res = await removePhoto();
       if ("error" in res && res.error) {
         throw new Error(res.error);
       }
-      return "imageUrl" in res ? res.imageUrl : undefined;
     },
-    onSuccess: (imageUrl) => {
-      patchImage({ imageUrl: imageUrl ?? googlePicture });
-      toast.success("Profile photo updated.");
+    onSuccess: () => {
+      patchImage({ imageUrl: null });
+      toast.success("Profile photo removed.");
     },
     onError: (err) => {
       toast.error(
-        err instanceof Error ? err.message : "Couldn't update photo.",
+        err instanceof Error ? err.message : "Couldn't remove photo.",
       );
     },
   });
@@ -234,29 +231,33 @@ export function ProfileMedia({ user }: { user: UserWithAccount }) {
               <p className="text-xs text-muted-foreground">
                 JPG, PNG, or WebP, up to{" "}
                 {MAX_AVATAR_SOURCE_BYTES / (1024 * 1024)}MB.
+                {user.imageUrl
+                  ? " Remove it to go back to your default picture."
+                  : " Until then you're on your default picture."}
               </p>
             </div>
           </div>
 
           <div className="flex justify-end gap-2">
-            {uploadsAvailable && (
-              <Button type="button" onClick={() => pickFile("avatar")}>
-                <ImagePlusIcon className="size-4" />
-                Upload photo
-              </Button>
-            )}
-
-            {googlePicture && (
+            {user.imageUrl && (
               <Button
                 type="button"
                 variant="outline"
-                disabled={googlePhotoMutation.isPending}
-                onClick={() => googlePhotoMutation.mutate()}
+                disabled={removePhotoMutation.isPending}
+                onClick={() => removePhotoMutation.mutate()}
               >
-                {googlePhotoMutation.isPending && (
+                {removePhotoMutation.isPending ? (
                   <Loader2Icon className="size-4 animate-spin" />
+                ) : (
+                  <Trash2Icon className="size-4" />
                 )}
-                Use Google Photo
+                Remove
+              </Button>
+            )}
+            {uploadsAvailable && (
+              <Button type="button" onClick={() => pickFile("avatar")}>
+                <ImagePlusIcon className="size-4" />
+                {user.imageUrl ? "Change photo" : "Upload photo"}
               </Button>
             )}
           </div>

--- a/apps/web/test/actions-profile-photo.test.ts
+++ b/apps/web/test/actions-profile-photo.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// argon2's precompiled .wasm import only resolves in the workers pool; this
+// node-pool suite pulls argon2 in transitively via actionsApp but never calls it.
+vi.mock("../src/server-lib/argon2", () => ({
+  hash: async () => "",
+  verify: async () => false,
+}));
+
+import { userTable } from "@umamin/db/schema/user";
+import { eq } from "drizzle-orm";
+import type { Db } from "../src/server-lib/db";
+import { authed, buildApp, call, callJson } from "./helpers/actions";
+import { makeTestDb } from "./helpers/db";
+
+const GOOGLE_PHOTO = "https://lh3.googleusercontent.com/a/abc123";
+
+async function seedUser(db: Db, imageUrl: string | null) {
+  await db
+    .insert(userTable)
+    .values({ id: "user_1", username: "alice", imageUrl });
+}
+
+const imageUrlOf = (db: Db) =>
+  db
+    .select({ imageUrl: userTable.imageUrl })
+    .from(userTable)
+    .where(eq(userTable.id, "user_1"))
+    .then(([row]) => row?.imageUrl);
+
+describe("profile photo actions (real libSQL)", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("removes an uploaded photo, falling back to the default picture", async () => {
+    await seedUser(db, "https://cdn.test/avatars/alice.webp");
+
+    const { json } = await callJson(
+      buildApp(db, authed("user_1")),
+      "removeProfilePhotoAction",
+    );
+
+    expect(json).toEqual({ success: true });
+    expect(await imageUrlOf(db)).toBeNull();
+  });
+
+  it("removes a Google photo left over from an older signup", async () => {
+    // Accounts created before the signup path stopped adopting the Google photo
+    // still carry one, and this is the only way they can clear it now that
+    // "Use Google Photo" and the Display Picture toggle are gone.
+    await seedUser(db, GOOGLE_PHOTO);
+
+    await call(buildApp(db, authed("user_1")), "removeProfilePhotoAction");
+
+    expect(await imageUrlOf(db)).toBeNull();
+  });
+
+  it("requires a session", async () => {
+    await seedUser(db, GOOGLE_PHOTO);
+
+    const res = await call(
+      buildApp(db, { session: null, user: null, source: null }),
+      "removeProfilePhotoAction",
+    );
+
+    expect(res.status).toBe(401);
+    expect(await imageUrlOf(db)).toBe(GOOGLE_PHOTO);
+  });
+
+  // No action applies an avatar by URL any more: photos come from the R2 upload
+  // path, and everything else is the account's own blobatar. Re-adding either
+  // endpoint re-opens the raw <img src> tracking vector the host allowlist
+  // used to guard.
+  it.each([
+    "updateAvatarAction",
+    "toggleDisplayPictureAction",
+  ])("no longer exposes %s", async (name) => {
+    await seedUser(db, null);
+
+    const res = await call(buildApp(db, authed("user_1")), name, GOOGLE_PHOTO);
+
+    expect(res.status).toBe(404);
+    expect(await imageUrlOf(db)).toBeNull();
+  });
+});

--- a/apps/web/test/auth-google-callback.test.ts
+++ b/apps/web/test/auth-google-callback.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The callback resolves its db through getDb(env) rather than the c.set("db")
+// seam the action tests use, so the module is stubbed to hand back the same
+// in-memory libSQL instance. arctic's token exchange and the denylist /
+// rate-limit gates are stubbed to their pass-through outcome; what's under test
+// is the upsert, which runs its true SQL against real migrations.
+const state = {
+  db: null as Db | null,
+  claims: {} as Record<string, unknown>,
+};
+
+vi.mock("../src/server-lib/db", () => ({
+  getDb: () => state.db,
+}));
+
+vi.mock("../src/server-lib/oauth", () => ({
+  buildGoogle: () => ({
+    validateAuthorizationCode: async () => ({ idToken: () => "stub.id.token" }),
+  }),
+}));
+
+vi.mock("arctic", () => ({
+  decodeIdToken: () => state.claims,
+  OAuth2RequestError: class extends Error {},
+  generateState: () => "s",
+  generateCodeVerifier: () => "v",
+}));
+
+vi.mock("../src/server-lib/ip-denylist", () => ({
+  isIpDenied: async () => false,
+}));
+
+vi.mock("../src/server-lib/ratelimit", () => ({
+  checkRateLimit: async () => true,
+}));
+
+import { accountTable, userTable } from "@umamin/db/schema/user";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { googleAuthApp } from "../src/api/auth/google";
+import type { AppBindings } from "../src/server-lib/context";
+import {
+  GOOGLE_OAUTH_CODE_VERIFIER_COOKIE_NAME,
+  GOOGLE_OAUTH_INTENT_COOKIE_NAME,
+  GOOGLE_OAUTH_STATE_COOKIE_NAME,
+  SESSION_COOKIE_NAME,
+} from "../src/server-lib/cookies";
+import type { Db } from "../src/server-lib/db";
+import type { AppEnv } from "../src/server-lib/env";
+import {
+  __clearSessionCache,
+  createSession,
+  generateSessionToken,
+} from "../src/server-lib/session";
+import { makeTestDb } from "./helpers/db";
+
+const GOOGLE_PHOTO = "https://lh3.googleusercontent.com/a/abc123";
+
+const FAKE_CTX = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+// Matching state + a code verifier are all the CSRF/PKCE gate needs; `intent`
+// is what decides whether the callback may provision an account.
+function callback(intent: "register" | "login", session?: string) {
+  const app = new Hono<AppBindings>().route("/auth/google", googleAuthApp);
+  const cookies = [
+    `${GOOGLE_OAUTH_STATE_COOKIE_NAME}=st`,
+    `${GOOGLE_OAUTH_CODE_VERIFIER_COOKIE_NAME}=cv`,
+    `${GOOGLE_OAUTH_INTENT_COOKIE_NAME}=${intent}`,
+    ...(session ? [`${SESSION_COOKIE_NAME}=${session}`] : []),
+  ].join("; ");
+
+  return app.request(
+    "/auth/google/callback?code=c&state=st",
+    { headers: { cookie: cookies } },
+    { TURSO_CONNECTION_URL: "", TURSO_AUTH_TOKEN: "" } as unknown as AppEnv,
+    FAKE_CTX,
+  );
+}
+
+describe("google oauth callback (real libSQL)", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    __clearSessionCache();
+    db = await makeTestDb();
+    state.db = db;
+    state.claims = {
+      sub: "google-sub-1",
+      email: "alice@example.com",
+      picture: GOOGLE_PHOTO,
+    };
+  });
+
+  it("provisions a Google signup with no profile photo", async () => {
+    const res = await callback("register");
+    expect(res.status).toBe(302);
+
+    const [created] = await db.select().from(userTable);
+    // The default profile picture is the account's own blobatar. Adopting the
+    // Google photo would publish a real face for an anonymous-messaging
+    // account nobody opted into.
+    expect(created.imageUrl).toBeNull();
+    expect(created.username).toMatch(/^user_/);
+  });
+
+  it("still records the Google photo on the linked account row", async () => {
+    await callback("register");
+
+    const [account] = await db.select().from(accountTable);
+    // Kept for the "Google Account" card in Settings — it identifies which
+    // account is linked, and is never read as a profile picture.
+    expect(account.picture).toBe(GOOGLE_PHOTO);
+    expect(account.email).toBe("alice@example.com");
+  });
+
+  it("leaves an existing photo alone when linking Google to an account", async () => {
+    const uploaded = "https://cdn.test/avatars/alice.webp";
+    await db.insert(userTable).values({
+      id: "user_1",
+      username: "alice",
+      imageUrl: uploaded,
+    });
+    const token = generateSessionToken();
+    await createSession(db, token, "user_1");
+
+    const res = await callback("login", token);
+    expect(res.status).toBe(302);
+
+    const [after] = await db
+      .select()
+      .from(userTable)
+      .where(eq(userTable.id, "user_1"));
+    expect(after.imageUrl).toBe(uploaded);
+  });
+
+  it("does not adopt the Google photo for a linking user who has none", async () => {
+    await db
+      .insert(userTable)
+      .values({ id: "user_2", username: "bob", imageUrl: null });
+    const token = generateSessionToken();
+    await createSession(db, token, "user_2");
+
+    await callback("login", token);
+
+    const [after] = await db
+      .select()
+      .from(userTable)
+      .where(eq(userTable.id, "user_2"));
+    expect(after.imageUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
Ships **v7.6.1**. Follow-up to v7.6.0 (blobatar default profile pictures), which is already tagged and released.

## What changes

**The Google photo is never a profile picture again** — `api/auth/google.ts`
- Signing up with Google no longer seeds `imageUrl`. New accounts start on their blobatar.
- Linking Google to an existing account no longer adopts the photo either. That branch used to overwrite `imageUrl` whenever it happened to be empty.
- `accountTable.picture` is still written — the "Google Account" card in Settings uses it to show *which* account is linked, and it is never read as a profile picture.

**Both photo pickers are gone**
- "Use Google Photo" (Settings → Profile Photo), along with the `updateAvatarAction` endpoint behind it.
- The "Display Picture" switch (Settings → Privacy), along with `toggleDisplayPictureAction`. It was never a hide toggle: switching it off called `deleteR2Avatar` and permanently deleted the photo, which its own helper text admitted.
- Those were the last two callers of `ALLOWED_AVATAR_HOSTS` / `isAllowedAvatarUrl`, so **no endpoint applies an avatar by URL any more**. Photos come from the R2 upload path only, which closes the raw `<img src>` vector the host allowlist existed to narrow.

**New "Remove photo"** — sits beside Upload under Profile Photo in General settings, ordered and styled to match the Banner section directly below it (outline + trash first, then the primary button, which now reads "Change photo" when one is set). Clearing `imageUrl` drops you back to your blobatar.

## Note for review

Accounts that **already** show a Google photo keep it. Clearing them would be a destructive migration over real users' profiles, so it's deliberately left out — they can now clear it themselves with Remove photo, and there's a test covering exactly that path.

The CHANGELOG diff also moves these bullets out of the published 7.6.0 section into a new 7.6.1. The 7.6.0 section is byte-identical to `main`, so no published release notes are rewritten.

## Tests

9 new, both against real migrations via in-memory libSQL:
- `test/auth-google-callback.test.ts` — mounts the real OAuth callback (arctic, `getDb`, denylist and rate limit stubbed) and covers signup, linking-with-a-photo, and linking-without-one. Mutation-checked: restoring the old `imageUrl` seeding fails exactly the two tests that should.
- `test/actions-profile-photo.test.ts` — removing an uploaded photo, removing a **leftover Google URL**, the 401 guard, and that both retired endpoints 404.

`pnpm test` 342 passed · `test:workers` 120 passed · typecheck clean · Biome clean (700 files) · build derives `VITE_APP_VERSION=v7.6.1` and `sw.js?v=v7.6.1`, so PWA caches rotate.

## Unrelated flake spotted

`test/session.test.ts` → "bounds the in-isolate session cache" failed once at 5.7s, then passed on targeted and full re-runs. It does ~180 sequential libSQL writes against the 5s default timeout. Pre-existing and untouched here, but it can bite CI.
